### PR TITLE
New models: bounded integers, Vec (#5), and String (#3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ let input = NavigationReport {
     battery_ok: Some(true),
 };
 
-let compressed = input.encode_bytes();
+let compressed = input.encode_bytes().unwrap();
 let output = NavigationReport::decode_bytes(&compressed).unwrap();
 
 assert_eq!(input, output);

--- a/examples/navigation_report.rs
+++ b/examples/navigation_report.rs
@@ -37,7 +37,7 @@ fn main() {
     // 53 bits. See <https://libdccl.org/3.0/>.
     println!("\nsize report:\n{}", NavigationReport::size_report());
 
-    let compressed = input.encode_bytes();
+    let compressed = input.encode_bytes().unwrap();
 
     println!("bytes: {:x?}, length: {}", compressed, compressed.len());
 

--- a/examples/struct_enum.rs
+++ b/examples/struct_enum.rs
@@ -17,7 +17,7 @@ fn y_model() -> FloatModel<f64> {
 }
 
 impl Encodeable for MyEnum {
-    fn encode<W>(&self, visitor: &mut minnow::EncodeVisitor<W>) -> std::io::Result<()>
+    fn encode<W>(&self, visitor: &mut minnow::EncodeVisitor<W>) -> Result<(), minnow::EncodeError>
     where
         W: bitstream_io::BitWrite,
     {
@@ -82,7 +82,7 @@ fn main() {
     for input in [MyEnum::A { x: -5.0, y: 15.0 }, MyEnum::B] {
         println!("input: {input:?}");
 
-        let compressed = input.encode_bytes();
+        let compressed = input.encode_bytes().unwrap();
         println!("bytes: {}", compressed.len());
 
         let output = MyEnum::decode_bytes(&compressed).expect("round-trip should succeed");

--- a/examples/struct_variants.rs
+++ b/examples/struct_variants.rs
@@ -28,7 +28,7 @@ fn main() {
     ] {
         println!("input: {input:?}");
 
-        let compressed = input.encode_bytes();
+        let compressed = input.encode_bytes().unwrap();
         println!("bytes: {}", compressed.len());
 
         let output = Shape::decode_bytes(&compressed).expect("round-trip should succeed");

--- a/minnow-derive/src/parse.rs
+++ b/minnow-derive/src/parse.rs
@@ -48,6 +48,11 @@ macro_rules! impl_signed_number {
 
 impl_signed_number!(f64);
 impl_signed_number!(i8);
+// `i128` is wide enough to hold the full range of every integer type
+// `IntModel` supports (`u8..=u64`, `i8..=i64`), so `int(min = ..., max =
+// ...)` parses both bounds through this one signed representation regardless
+// of the field's actual integer type; see `Model::config_tokens`.
+impl_signed_number!(i128);
 
 #[derive(FromMeta)]
 pub enum Model {
@@ -56,8 +61,25 @@ pub enum Model {
         max: Number<f64>,
         precision: Number<i8>,
     },
+    /// `#[encode(int(min = a, max = b))]` — a bounded integer, uniform over
+    /// `a..=b`. Lowers to `minnow::IntModel::new(a..=b)`; the target integer
+    /// type is inferred from the field, not from this attribute (see
+    /// [`Model::config_tokens`]).
+    Int {
+        min: Number<i128>,
+        max: Number<i128>,
+    },
     String {
         max_length: usize,
+    },
+    /// `#[encode(seq(max_len = N, elem = <expr>))]` — a bounded `Vec<T>`,
+    /// length-prefixed over `0..=N`. `elem` is the per-element config
+    /// expression; it may be omitted when `T::Config: Default`, in which case
+    /// it lowers to `Default::default()` like an unannotated field would.
+    Seq {
+        max_len: u32,
+        #[darling(default)]
+        elem: Option<syn::Expr>,
     },
     /// `#[encode(config = <expr>)]` — an arbitrary Rust expression evaluated
     /// as the field's runtime config. This is the escape hatch every other
@@ -92,8 +114,34 @@ impl Model {
                 minnow::FloatModel::new( #min ..= #max, #precision )
                     .expect("model bounds validated at compile time")
             },
+            Some(Self::Int {
+                min: Number(min),
+                max: Number(max),
+            }) => {
+                // Emit unsuffixed integer literals so their type is inferred
+                // from context (the field's concrete integer type, via
+                // `IntModel<T>`'s `T`) rather than fixed to `i128`.
+                let min = proc_macro2::Literal::i128_unsuffixed(*min);
+                let max = proc_macro2::Literal::i128_unsuffixed(*max);
+                quote! {
+                    minnow::IntModel::new( #min ..= #max )
+                        .expect("model bounds validated at compile time")
+                }
+            }
             Some(Self::String { max_length }) => {
-                quote! { minnow::StringModel::new( #max_length ) }
+                quote! {
+                    minnow::StringModel::new( #max_length )
+                        .expect("model bounds validated at compile time")
+                }
+            }
+            Some(Self::Seq { max_len, elem }) => {
+                let elem = elem.as_ref().map_or_else(
+                    || quote! { ::core::default::Default::default() },
+                    |expr| quote! { #expr },
+                );
+                quote! {
+                    minnow::SeqModel { max_len: #max_len, elem: #elem }
+                }
             }
             Some(Self::Config(expr)) => quote! { #expr },
             // Fall back to `Default::default()` rather than a literal `()` so
@@ -108,44 +156,99 @@ impl Model {
     /// Validate a model's parameters at macro-expansion time so that invalid
     /// bounds become a clean compile error rather than a runtime panic.
     fn validate(&self) -> Result<(), String> {
-        if let Model::Float {
-            min: Number(min),
-            max: Number(max),
-            precision: Number(precision),
-        } = self
-        {
-            if !min.is_finite() || !max.is_finite() {
-                return Err("float model bounds must be finite (neither NaN nor infinite)".into());
+        match self {
+            Model::Float {
+                min: Number(min),
+                max: Number(max),
+                precision: Number(precision),
+            } => {
+                if !min.is_finite() || !max.is_finite() {
+                    return Err(
+                        "float model bounds must be finite (neither NaN nor infinite)".into(),
+                    );
+                }
+                if min > max {
+                    return Err(format!(
+                        "float model lower bound ({min}) must not exceed the upper bound ({max})"
+                    ));
+                }
+                // This must mirror `FloatModel::new` exactly (same f64
+                // arithmetic, then the same *integer* comparison) so that
+                // anything accepted here is also accepted at runtime.
+                // Comparing in f64 instead would disagree near the boundary,
+                // where `steps + 1.0` rounds back to `MAX_DENOMINATOR`.
+                let multiplier = 10_f64.powi(i32::from(*precision));
+                let steps = ((max - min) * multiplier).round();
+                let steps = num_traits::ToPrimitive::to_u128(&steps).ok_or_else(|| {
+                    format!(
+                        "float model denominator exceeds the maximum ({MAX_DENOMINATOR}) \
+                         permitted at precision 64; narrow the range or reduce the precision"
+                    )
+                })?;
+                // `denominator = steps + 1`; reject before the `+ 1` can
+                // overflow or exceed the bound.
+                if steps >= MAX_DENOMINATOR {
+                    return Err(format!(
+                        "float model denominator ({}) exceeds the maximum ({MAX_DENOMINATOR}) \
+                         permitted at precision 64; narrow the range or reduce the precision",
+                        steps.saturating_add(1)
+                    ));
+                }
+                Ok(())
             }
-            if min > max {
-                return Err(format!(
-                    "float model lower bound ({min}) must not exceed the upper bound ({max})"
-                ));
+            Model::Int {
+                min: Number(min),
+                max: Number(max),
+            } => {
+                if min > max {
+                    return Err(format!(
+                        "int model lower bound ({min}) must not exceed the upper bound ({max})"
+                    ));
+                }
+                // This must mirror `IntModel::new` exactly: an `i128`
+                // difference, then the same integer comparison against
+                // `MAX_DENOMINATOR`.
+                let width = max.checked_sub(*min).ok_or_else(|| {
+                    "int model range width overflows i128; narrow the range".to_string()
+                })?;
+                let width = u128::try_from(width).map_err(|_| {
+                    "int model range width overflows i128; narrow the range".to_string()
+                })?;
+                // `denominator = width + 1`; reject before the `+ 1` can
+                // overflow or exceed the bound.
+                if width >= MAX_DENOMINATOR {
+                    return Err(format!(
+                        "int model denominator ({}) exceeds the maximum ({MAX_DENOMINATOR}) \
+                         permitted at precision 64; narrow the range",
+                        width.saturating_add(1)
+                    ));
+                }
+                Ok(())
             }
-            // This must mirror `FloatModel::new` exactly (same f64 arithmetic,
-            // then the same *integer* comparison) so that anything accepted
-            // here is also accepted at runtime. Comparing in f64 instead would
-            // disagree near the boundary, where `steps + 1.0` rounds back to
-            // `MAX_DENOMINATOR`.
-            let multiplier = 10_f64.powi(i32::from(*precision));
-            let steps = ((max - min) * multiplier).round();
-            let steps = num_traits::ToPrimitive::to_u128(&steps).ok_or_else(|| {
-                format!(
-                    "float model denominator exceeds the maximum ({MAX_DENOMINATOR}) permitted at \
-                     precision 64; narrow the range or reduce the precision"
-                )
-            })?;
-            // `denominator = steps + 1`; reject before the `+ 1` can overflow
-            // or exceed the bound.
-            if steps >= MAX_DENOMINATOR {
-                return Err(format!(
-                    "float model denominator ({}) exceeds the maximum ({MAX_DENOMINATOR}) \
-                     permitted at precision 64; narrow the range or reduce the precision",
-                    steps.saturating_add(1)
-                ));
+            Model::String { max_length } => {
+                // Mirrors `StringModel::new`: the only way construction can
+                // fail is `max_length` not fitting in the `u32` that backs
+                // `SeqModel::max_len` — a `u32`-bounded length model's
+                // denominator (`max_length + 1 <= 2^32`) is always far below
+                // `MAX_DENOMINATOR` (`~2^62`), so that's the only check
+                // needed here.
+                if u32::try_from(*max_length).is_err() {
+                    return Err(format!(
+                        "string max_length ({max_length}) exceeds the maximum representable \
+                         length ({})",
+                        u32::MAX
+                    ));
+                }
+                Ok(())
             }
+            // `Seq`'s `max_len` is already a `u32` by construction (parsed as
+            // one), and a `u32`-bounded length model's denominator can never
+            // exceed `MAX_DENOMINATOR` (see the `String` case above), so
+            // there is nothing further to validate here. The `elem`
+            // expression, like `Config`, cannot be checked at macro-expansion
+            // time.
+            Model::Seq { .. } | Model::Config(_) => Ok(()),
         }
-        Ok(())
     }
 }
 
@@ -300,6 +403,36 @@ mod tests {
         }
         ; "unit enum"
     )]
+    #[test_case(
+        quote! {
+            #[derive(Encodeable)]
+            pub struct Reading {
+                #[encode(int(min = -10, max = 10))]
+                pub x: i32,
+            }
+        }
+        ; "int"
+    )]
+    #[test_case(
+        quote! {
+            #[derive(Encodeable)]
+            pub struct Reading {
+                #[encode(seq(max_len = 8, elem = minnow::FloatModel::new(0.0..=1.0, 1).unwrap()))]
+                pub samples: Vec<f64>,
+            }
+        }
+        ; "seq with elem"
+    )]
+    #[test_case(
+        quote! {
+            #[derive(Encodeable)]
+            pub struct Reading {
+                #[encode(seq(max_len = 8))]
+                pub flags: Vec<bool>,
+            }
+        }
+        ; "seq without elem"
+    )]
     fn parse(tokens: TokenStream) {
         let parsed: syn::DeriveInput = syn::parse2(tokens).unwrap();
         let _receiver = Receiver::from_derive_input(&parsed).unwrap();
@@ -321,5 +454,58 @@ mod tests {
             precision: Number(0),
         };
         model.validate().is_ok()
+    }
+
+    /// The macro-time integer bounds check must agree with `IntModel::new`
+    /// exactly at the `MAX_DENOMINATOR` boundary. Unlike the float case this
+    /// is exact-integer arithmetic on both sides, so agreement is
+    /// straightforward — but still worth pinning down with a test.
+    #[test_case(4_611_686_018_427_387_902 => true; "largest width below the boundary is accepted")]
+    #[test_case(4_611_686_018_427_387_903 => false; "width equal to MAX_DENOMINATOR is rejected")]
+    fn int_boundary_agrees_with_runtime(max: i128) -> bool {
+        use super::{Model, Number};
+        let model = Model::Int {
+            min: Number(0),
+            max: Number(max),
+        };
+        model.validate().is_ok()
+    }
+
+    #[test]
+    fn int_rejects_inverted_bounds() {
+        use super::{Model, Number};
+        let model = Model::Int {
+            min: Number(10),
+            max: Number(-10),
+        };
+        assert!(model.validate().is_err());
+    }
+
+    #[test]
+    fn int_accepts_negative_range() {
+        use super::{Model, Number};
+        let model = Model::Int {
+            min: Number(-10),
+            max: Number(10),
+        };
+        assert!(model.validate().is_ok());
+    }
+
+    #[test]
+    fn string_rejects_max_length_over_u32() {
+        use super::Model;
+        let model = Model::String {
+            max_length: u32::MAX as usize + 1,
+        };
+        assert!(model.validate().is_err());
+    }
+
+    #[test]
+    fn string_accepts_max_length_at_u32_max() {
+        use super::Model;
+        let model = Model::String {
+            max_length: u32::MAX as usize,
+        };
+        assert!(model.validate().is_ok());
     }
 }

--- a/minnow-derive/src/parse.rs
+++ b/minnow-derive/src/parse.rs
@@ -60,6 +60,10 @@ pub enum Model {
         min: Number<f64>,
         max: Number<f64>,
         precision: Number<i8>,
+        /// `clamping` opts into coercing out-of-range values to the nearest
+        /// bound instead of an `EncodeError::OutOfRange`.
+        #[darling(default)]
+        clamping: bool,
     },
     /// `#[encode(int(min = a, max = b))]` — a bounded integer, uniform over
     /// `a..=b`. Lowers to `minnow::IntModel::new(a..=b)`; the target integer
@@ -68,6 +72,10 @@ pub enum Model {
     Int {
         min: Number<i128>,
         max: Number<i128>,
+        /// `clamping` opts into coercing out-of-range values to the nearest
+        /// bound instead of an `EncodeError::OutOfRange`.
+        #[darling(default)]
+        clamping: bool,
     },
     String {
         max_length: usize,
@@ -110,14 +118,21 @@ impl Model {
                 min: Number(min),
                 max: Number(max),
                 precision: Number(precision),
-            }) => quote! {
-                minnow::FloatModel::new( #min ..= #max, #precision )
-                    .expect("model bounds validated at compile time")
-            },
+                clamping,
+            }) => {
+                let clamping = clamping.then(|| quote! { .clamping() });
+                quote! {
+                    minnow::FloatModel::new( #min ..= #max, #precision )
+                        .expect("model bounds validated at compile time")
+                        #clamping
+                }
+            }
             Some(Self::Int {
                 min: Number(min),
                 max: Number(max),
+                clamping,
             }) => {
+                let clamping = clamping.then(|| quote! { .clamping() });
                 // Emit unsuffixed integer literals so their type is inferred
                 // from context (the field's concrete integer type, via
                 // `IntModel<T>`'s `T`) rather than fixed to `i128`.
@@ -126,6 +141,7 @@ impl Model {
                 quote! {
                     minnow::IntModel::new( #min ..= #max )
                         .expect("model bounds validated at compile time")
+                        #clamping
                 }
             }
             Some(Self::String { max_length }) => {
@@ -161,6 +177,7 @@ impl Model {
                 min: Number(min),
                 max: Number(max),
                 precision: Number(precision),
+                clamping: _,
             } => {
                 if !min.is_finite() || !max.is_finite() {
                     return Err(
@@ -199,6 +216,7 @@ impl Model {
             Model::Int {
                 min: Number(min),
                 max: Number(max),
+                clamping: _,
             } => {
                 if min > max {
                     return Err(format!(
@@ -452,6 +470,7 @@ mod tests {
             min: Number(0.0),
             max: Number(max),
             precision: Number(0),
+            clamping: false,
         };
         model.validate().is_ok()
     }
@@ -467,6 +486,7 @@ mod tests {
         let model = Model::Int {
             min: Number(0),
             max: Number(max),
+            clamping: false,
         };
         model.validate().is_ok()
     }
@@ -477,6 +497,7 @@ mod tests {
         let model = Model::Int {
             min: Number(10),
             max: Number(-10),
+            clamping: false,
         };
         assert!(model.validate().is_err());
     }
@@ -487,6 +508,7 @@ mod tests {
         let model = Model::Int {
             min: Number(-10),
             max: Number(10),
+            clamping: false,
         };
         assert!(model.validate().is_ok());
     }

--- a/minnow-derive/src/write.rs
+++ b/minnow-derive/src/write.rs
@@ -292,7 +292,7 @@ fn write_struct(struct_data: StructData) -> TokenStream {
                 #report_body
             }
 
-            fn encode_with_config<W>(&self, visitor: &mut minnow::EncodeVisitor<W>, _config: ()) -> std::io::Result<()>
+            fn encode_with_config<W>(&self, visitor: &mut minnow::EncodeVisitor<W>, _config: ()) -> ::core::result::Result<(), minnow::EncodeError>
             where
                 W: bitstream_io::BitWrite,
             {
@@ -486,7 +486,7 @@ fn write_enum(enum_data: EnumData) -> TokenStream {
                 minnow::SizeReport::sum(::std::vec![ #( #report_children ),* ])
             }
 
-            fn encode_with_config<W>(&self, visitor: &mut minnow::EncodeVisitor<W>, _config: ()) -> std::io::Result<()>
+            fn encode_with_config<W>(&self, visitor: &mut minnow::EncodeVisitor<W>, _config: ()) -> ::core::result::Result<(), minnow::EncodeError>
             where
                 W: bitstream_io::BitWrite {
                 let model = #model_ctor;

--- a/src/encodeable.rs
+++ b/src/encodeable.rs
@@ -1,9 +1,7 @@
-use std::io;
-
 use bitstream_io::{BigEndian, BitRead, BitReader, BitWrite, BitWriter};
 
 use crate::{
-    DecodeError, PRECISION, SizeReport,
+    DecodeError, EncodeError, PRECISION, SizeReport,
     encodeable_custom::EncodeableCustom,
     visitor::{DecodeVisitor, EncodeVisitor},
 };
@@ -19,9 +17,9 @@ pub trait Encodeable {
     ///
     /// # Errors
     ///
-    /// This method can fail if the [`EncodeVisitor`]'s underlying writer cannot
-    /// be written to.
-    fn encode<W>(&self, visitor: &mut EncodeVisitor<W>) -> io::Result<()>
+    /// Returns [`EncodeError`] if a value lies outside its model's configured
+    /// domain, or if the underlying writer cannot be written to.
+    fn encode<W>(&self, visitor: &mut EncodeVisitor<W>) -> Result<(), EncodeError>
     where
         W: BitWrite;
 
@@ -58,27 +56,20 @@ pub trait Encodeable {
 
     /// Encode the struct into a [`Vec<u8>`].
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// This method is infallible in practice: writing to a `Vec<u8>` cannot
-    /// produce an I/O error. It will only panic if that invariant is somehow
-    /// violated.
-    fn encode_bytes(&self) -> Vec<u8> {
+    /// Returns [`EncodeError`] if a value lies outside its model's configured
+    /// domain. Writing to the `Vec<u8>` itself cannot fail.
+    fn encode_bytes(&self) -> Result<Vec<u8>, EncodeError> {
         let mut bit_writer = BitWriter::endian(Vec::new(), BigEndian);
         let mut encoder = EncodeVisitor::new(PRECISION, &mut bit_writer);
 
-        // Writing to a `Vec<u8>` is infallible, so these operations cannot fail.
-        self.encode(&mut encoder)
-            .expect("writing to Vec<u8> is infallible");
-        encoder.flush().expect("writing to Vec<u8> is infallible");
-        bit_writer
-            .byte_align()
-            .expect("writing to Vec<u8> is infallible");
-        bit_writer
-            .flush()
-            .expect("writing to Vec<u8> is infallible");
+        self.encode(&mut encoder)?;
+        encoder.flush()?;
+        bit_writer.byte_align()?;
+        bit_writer.flush()?;
 
-        bit_writer.into_writer()
+        Ok(bit_writer.into_writer())
     }
 
     /// Decode the struct using the provided [`DecodeVisitor`].
@@ -128,7 +119,7 @@ where
     T: EncodeableCustom<Config = C>,
     C: Default,
 {
-    fn encode<W>(&self, visitor: &mut EncodeVisitor<W>) -> io::Result<()>
+    fn encode<W>(&self, visitor: &mut EncodeVisitor<W>) -> Result<(), EncodeError>
     where
         W: BitWrite,
     {

--- a/src/encodeable_custom.rs
+++ b/src/encodeable_custom.rs
@@ -1,9 +1,7 @@
-use std::io;
-
 use bitstream_io::{BigEndian, BitRead, BitReader, BitWrite, BitWriter};
 
 use crate::{
-    DecodeError, PRECISION, SizeReport, Weight,
+    DecodeError, EncodeError, PRECISION, SizeReport, Weight,
     visitor::{DecodeVisitor, EncodeVisitor},
 };
 
@@ -70,40 +68,33 @@ pub trait EncodeableCustom {
     ///
     /// # Errors
     ///
-    /// This method can fail if the [`EncodeVisitor`]'s underlying writer cannot
-    /// be written to.
+    /// Returns [`EncodeError`] if a value lies outside its model's configured
+    /// domain (see [`EncodeError::OutOfRange`] and the saturation opt-in
+    /// documented there), or if the underlying writer cannot be written to.
     fn encode_with_config<W>(
         &self,
         visitor: &mut EncodeVisitor<W>,
         config: Self::Config,
-    ) -> io::Result<()>
+    ) -> Result<(), EncodeError>
     where
         W: BitWrite;
 
     /// Encode the struct into a [`Vec<u8>`] using the provided configuration.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// This method is infallible in practice: writing to a `Vec<u8>` cannot
-    /// produce an I/O error. It will only panic if that invariant is somehow
-    /// violated.
-    fn encode_bytes_with_config(&self, config: Self::Config) -> Vec<u8> {
+    /// Returns [`EncodeError`] if a value lies outside its model's configured
+    /// domain. Writing to the `Vec<u8>` itself cannot fail.
+    fn encode_bytes_with_config(&self, config: Self::Config) -> Result<Vec<u8>, EncodeError> {
         let mut bit_writer = BitWriter::endian(Vec::new(), BigEndian);
         let mut encoder = EncodeVisitor::new(PRECISION, &mut bit_writer);
 
-        self.encode_with_config(&mut encoder, config)
-            .expect("can't get io errors when writing to Vec<u8>");
-        encoder
-            .flush()
-            .expect("can't get io errors when writing to Vec<u8>");
-        bit_writer
-            .byte_align()
-            .expect("can't get io errors when writing to Vec<u8>");
-        bit_writer
-            .flush()
-            .expect("can't get io errors when writing to Vec<u8>");
+        self.encode_with_config(&mut encoder, config)?;
+        encoder.flush()?;
+        bit_writer.byte_align()?;
+        bit_writer.flush()?;
 
-        bit_writer.into_writer()
+        Ok(bit_writer.into_writer())
     }
 
     /// Decode the struct using the provided configuration and

--- a/src/encodeable_custom.rs
+++ b/src/encodeable_custom.rs
@@ -148,7 +148,10 @@ pub trait EncodeableCustom {
         // weighting the two ends coincide, pinning the length exactly and
         // catching truncation; manual `#[encode(weight)]` overrides widen the
         // window but it still never rejects a genuinely valid encoding.
-        let expected = Self::report(&config).total_bytes();
+        // Computed from the scalar bit bounds directly — building the full
+        // `SizeReport` tree here would be wasted work on every decode.
+        let expected =
+            crate::report::bytes_for(Self::worst_case_bits(&config) + crate::TERMINATION_BITS);
         let lower = crate::report::bytes_for(Self::best_case_bits(&config));
         let actual = bytes.len();
         if actual < lower || actual > expected {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-//! Error types produced while decoding.
+//! Error types produced while encoding and decoding.
 
 /// An error that can occur while decoding a value from a stream of bits.
 ///
@@ -57,4 +57,57 @@ pub enum DecodeError {
     /// panicking on the `unwrap` a naive implementation might reach for.
     #[error("decoded bytes are not valid UTF-8: {0}")]
     InvalidUtf8(#[from] std::string::FromUtf8Error),
+}
+
+/// An error that can occur while encoding a value.
+///
+/// Encoding is fallible **by design**: a value outside a model's configured
+/// domain is a broken caller assumption, and silently coercing it would
+/// deliver plausible-but-wrong data to the receiver. In-range quantisation
+/// (rounding to the model's declared precision) is not an error — its loss is
+/// bounded by the precision the schema explicitly declares — whereas
+/// out-of-range loss is unbounded, so it is surfaced here instead. Models
+/// with a meaningful nearest-value projection offer clamping as an explicit
+/// opt-in ([`FloatModel::clamping`](crate::FloatModel::clamping),
+/// [`IntModel::clamping`](crate::IntModel::clamping)).
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum EncodeError {
+    /// The value lies outside the model's configured `min..=max` range, and
+    /// the model has not opted into clamping.
+    #[error("value {value} is outside the configured range {min}..={max}")]
+    OutOfRange {
+        /// The offending value.
+        value: String,
+        /// The model's lower bound.
+        min: String,
+        /// The model's upper bound.
+        max: String,
+    },
+
+    /// The value is NaN or infinite, which no bounded model can represent.
+    ///
+    /// Clamping does not apply: there is no nearest representable value to
+    /// a NaN, so this is an error even in saturating mode.
+    #[error("value {value} is not finite")]
+    NonFinite {
+        /// The offending value.
+        value: String,
+    },
+
+    /// A sequence has more elements than the model's configured `max_len`.
+    ///
+    /// Sequences have no clamping mode: truncation would silently drop
+    /// elements, which is not a nearest-value projection.
+    #[error("sequence of {len} elements exceeds the configured maximum length ({max_len})")]
+    TooLong {
+        /// The number of elements in the sequence.
+        len: usize,
+        /// The model's maximum length.
+        max_len: u32,
+    },
+
+    /// The underlying writer could not be written to.
+    #[error("i/o error while encoding: {0}")]
+    Io(#[from] std::io::Error),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -47,4 +47,14 @@ pub enum DecodeError {
         /// The number of bytes actually supplied.
         actual: usize,
     },
+
+    /// The decoded byte sequence for a [`String`] field was not valid UTF-8.
+    ///
+    /// [`String`]'s wire format (see [`crate::StringModel`]) is a bounded
+    /// sequence of raw bytes; any byte value round-trips, but not every byte
+    /// sequence is valid UTF-8. A corrupt or malicious stream can decode to a
+    /// byte sequence that isn't, which this variant reports rather than
+    /// panicking on the `unwrap` a naive implementation might reach for.
+    #[error("decoded bytes are not valid UTF-8: {0}")]
+    InvalidUtf8(#[from] std::string::FromUtf8Error),
 }

--- a/src/float.rs
+++ b/src/float.rs
@@ -6,7 +6,7 @@ use std::{
 use arithmetic_coding::one_shot;
 use num_traits::Float;
 
-use crate::{MAX_DENOMINATOR, ModelError};
+use crate::{EncodeError, MAX_DENOMINATOR, ModelError};
 
 /// A [`Model`](arithmetic_coding::Model) which (lossily) encodes and decodes
 /// floating point values.
@@ -19,6 +19,7 @@ where
     min: F,
     max: F,
     precision: i8,
+    clamping: bool,
 }
 
 impl<F> Default for FloatModel<F>
@@ -38,7 +39,8 @@ where
 {
     /// Create a new [`FloatModel`] with the given range and precision.
     ///
-    /// Values outside this range will be coerced to the nearest bound. The
+    /// Encoding a value outside this range is an [`EncodeError::OutOfRange`]
+    /// unless [clamping](FloatModel::clamping) mode is enabled. The
     /// `precision` is the number of decimal digits retained (it may be
     /// negative to quantise more coarsely than integers).
     ///
@@ -62,6 +64,7 @@ where
             min,
             max,
             precision,
+            clamping: false,
         };
 
         // The denominator is the number of distinguishable values in the range.
@@ -95,13 +98,61 @@ where
         self.scale(self.max) + 1
     }
 
+    /// Enable clamping mode: encoding a value outside `min..=max` clamps it
+    /// to the nearest bound instead of returning
+    /// [`EncodeError::OutOfRange`].
+    ///
+    /// In-range quantisation (rounding to the declared precision) always
+    /// happens and is not affected — its loss is bounded by half a
+    /// quantisation step, which the schema explicitly declares. Saturation
+    /// opts into *unbounded* loss at the boundaries, which is the right
+    /// policy for naturally saturating sources (sensor channels) and the
+    /// wrong one for most everything else — hence opt-in. NaN and infinite
+    /// values are an [`EncodeError::NonFinite`] in every mode: no nearest
+    /// representable value exists.
+    #[must_use]
+    pub const fn clamping(mut self) -> Self {
+        self.clamping = true;
+        self
+    }
+
+    /// Validate `value` against this model's domain, returning the value that
+    /// will actually be encoded.
+    ///
+    /// # Errors
+    ///
+    /// [`EncodeError::NonFinite`] for NaN/infinite values;
+    /// [`EncodeError::OutOfRange`] for values outside `min..=max` unless
+    /// [clamping](FloatModel::clamping) mode is enabled.
+    pub(crate) fn admit(&self, value: F) -> Result<F, EncodeError> {
+        if !value.is_finite() {
+            return Err(EncodeError::NonFinite {
+                value: format!("{value:?}"),
+            });
+        }
+        if value < self.min || value > self.max {
+            if self.clamping {
+                return Ok(num_traits::clamp(value, self.min, self.max));
+            }
+            return Err(EncodeError::OutOfRange {
+                value: format!("{value:?}"),
+                min: format!("{:?}", self.min),
+                max: format!("{:?}", self.max),
+            });
+        }
+        Ok(value)
+    }
+
     fn multiplier(&self) -> F {
         F::from(10_u32).unwrap().powi(self.precision.into())
     }
 
     fn scale(&self, value: F) -> u128 {
-        let input = num_traits::clamp(value, self.min, self.max);
-        let float = ((input - self.min) * self.multiplier()).round();
+        debug_assert!(
+            value >= self.min && value <= self.max,
+            "scale is only called with admitted (in-range) values"
+        );
+        let float = ((value - self.min) * self.multiplier()).round();
         num_traits::ToPrimitive::to_u128(&float).unwrap()
     }
 
@@ -141,7 +192,7 @@ mod tests {
     use test_case::test_case;
 
     use super::FloatModel;
-    use crate::{MAX_DENOMINATOR, ModelError};
+    use crate::{EncodeError, MAX_DENOMINATOR, ModelError};
 
     #[test]
     fn denominator() {
@@ -149,6 +200,7 @@ mod tests {
             min: 0.0,
             max: 1.0,
             precision: 1,
+            clamping: false,
         };
 
         assert_eq!(model.denominator(), 11);
@@ -157,12 +209,12 @@ mod tests {
     #[test_case(0.0 => 0)]
     #[test_case(0.5 => 5)]
     #[test_case(1.0 => 10)]
-    #[test_case(1.1 => 10)]
     fn scale(input: f64) -> u128 {
         let model = FloatModel {
             min: 0.0,
             max: 1.0,
             precision: 1,
+            clamping: false,
         };
 
         model.scale(input)
@@ -176,6 +228,7 @@ mod tests {
             min: 0.0,
             max: 1.0,
             precision: 1,
+            clamping: false,
         };
 
         model.probability(&input).unwrap()
@@ -191,6 +244,7 @@ mod tests {
             min: 0.0,
             max: 1.0,
             precision: 1,
+            clamping: false,
         };
 
         model.symbol(value)
@@ -234,5 +288,29 @@ mod tests {
         // A billion distinguishable values is far below MAX_DENOMINATOR (2^62).
         const _: () = assert!(MAX_DENOMINATOR > 1_000_000_000);
         assert!(FloatModel::new(0.0..=1_000_000_000.0, 0).is_ok());
+    }
+
+    /// Out-of-range values are an error by default, clamp only under the
+    /// explicit clamping opt-in, and NaN is an error in every mode.
+    #[test]
+    fn admit_semantics() {
+        let strict = FloatModel::new(0.0..=1.0, 1).unwrap();
+        assert!(matches!(
+            strict.admit(1.1),
+            Err(EncodeError::OutOfRange { .. })
+        ));
+        assert!(matches!(
+            strict.admit(f64::NAN),
+            Err(EncodeError::NonFinite { .. })
+        ));
+
+        let clamping = FloatModel::new(0.0..=1.0, 1).unwrap().clamping();
+        assert!((clamping.admit(1.1_f64).unwrap() - 1.0).abs() < f64::EPSILON);
+        assert!(clamping.admit(-5.0_f64).unwrap().abs() < f64::EPSILON);
+        // No nearest representable value exists for NaN, even when clamping.
+        assert!(matches!(
+            clamping.admit(f64::NAN),
+            Err(EncodeError::NonFinite { .. })
+        ));
     }
 }

--- a/src/float.rs
+++ b/src/float.rs
@@ -6,37 +6,7 @@ use std::{
 use arithmetic_coding::one_shot;
 use num_traits::Float;
 
-use crate::MAX_DENOMINATOR;
-
-/// An error returned when a model cannot be constructed because its parameters
-/// violate the arithmetic coder's precision invariant (see
-/// [`MAX_DENOMINATOR`](crate::MAX_DENOMINATOR)) or are otherwise invalid.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-#[non_exhaustive]
-pub enum ModelError {
-    /// One or both of the supplied bounds was `NaN` or infinite.
-    #[error("model bounds must be finite (neither NaN nor infinite)")]
-    NonFiniteBounds,
-
-    /// The lower bound was greater than the upper bound.
-    #[error("model lower bound must not exceed the upper bound")]
-    InvertedBounds,
-
-    /// The resulting denominator exceeds
-    /// [`MAX_DENOMINATOR`](crate::MAX_DENOMINATOR).
-    #[error(
-        "model denominator ({denominator}) exceeds the maximum ({max}) permitted at precision \
-         {precision}; narrow the range or reduce the precision"
-    )]
-    DenominatorTooLarge {
-        /// The denominator that was requested.
-        denominator: u128,
-        /// The maximum permissible denominator.
-        max: u128,
-        /// The arithmetic coder precision in bits.
-        precision: u32,
-    },
-}
+use crate::{MAX_DENOMINATOR, ModelError};
 
 /// A [`Model`](arithmetic_coding::Model) which (lossily) encodes and decodes
 /// floating point values.
@@ -170,8 +140,8 @@ mod tests {
     use arithmetic_coding::fixed_length::Model;
     use test_case::test_case;
 
-    use super::{FloatModel, ModelError};
-    use crate::MAX_DENOMINATOR;
+    use super::FloatModel;
+    use crate::{MAX_DENOMINATOR, ModelError};
 
     #[test]
     fn denominator() {

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -1,10 +1,8 @@
-use std::io;
-
 use bitstream_io::{BitRead, BitWrite};
 
 use self::{one_shot::OneShot, weighted::WeightedModel};
 use crate::{
-    DecodeError, DecodeVisitor, EncodeVisitor, SizeReport, Weight,
+    DecodeError, DecodeVisitor, EncodeError, EncodeVisitor, SizeReport, Weight,
     encodeable_custom::EncodeableCustom, float::FloatModel,
 };
 
@@ -55,19 +53,19 @@ where
         &self,
         visitor: &mut EncodeVisitor<W>,
         config: T::Config,
-    ) -> io::Result<()>
+    ) -> Result<(), EncodeError>
     where
         W: BitWrite,
     {
         // Every value of `Option<T>` costs exactly `log₂(1 + W(T))` bits under
         // the shared weighted discriminant.
         let model = option_discriminant::<T>(&config);
-        match self {
-            Some(x) => {
-                visitor.encode_one(model, &1_u32)?;
-                x.encode_with_config(visitor, config)
-            }
-            None => visitor.encode_one(model, &0_u32),
+        if let Some(x) = self {
+            visitor.encode_one(model, &1_u32)?;
+            x.encode_with_config(visitor, config)
+        } else {
+            visitor.encode_one(model, &0_u32)?;
+            Ok(())
         }
     }
 
@@ -100,7 +98,11 @@ impl EncodeableCustom for () {
         Weight::ONE
     }
 
-    fn encode_with_config<W>(&self, _visitor: &mut EncodeVisitor<W>, _config: ()) -> io::Result<()>
+    fn encode_with_config<W>(
+        &self,
+        _visitor: &mut EncodeVisitor<W>,
+        _config: (),
+    ) -> Result<(), EncodeError>
     where
         W: BitWrite,
     {
@@ -132,11 +134,13 @@ impl EncodeableCustom for f64 {
         &self,
         visitor: &mut EncodeVisitor<W>,
         config: Self::Config,
-    ) -> io::Result<()>
+    ) -> Result<(), EncodeError>
     where
         W: BitWrite,
     {
-        visitor.encode_one(config, self)
+        let value = config.admit(*self)?;
+        visitor.encode_one(config, &value)?;
+        Ok(())
     }
 
     fn decode_with_config<R>(
@@ -158,13 +162,18 @@ impl EncodeableCustom for bool {
         Weight::new(2)
     }
 
-    fn encode_with_config<W>(&self, visitor: &mut EncodeVisitor<W>, _config: ()) -> io::Result<()>
+    fn encode_with_config<W>(
+        &self,
+        visitor: &mut EncodeVisitor<W>,
+        _config: (),
+    ) -> Result<(), EncodeError>
     where
         W: BitWrite,
     {
         let model = OneShot::<2>;
         let value = u32::from(*self);
-        visitor.encode_one(model, &value)
+        visitor.encode_one(model, &value)?;
+        Ok(())
     }
 
     fn decode_with_config<R>(
@@ -231,7 +240,7 @@ where
         &self,
         visitor: &mut EncodeVisitor<W>,
         config: T::Config,
-    ) -> io::Result<()>
+    ) -> Result<(), EncodeError>
     where
         W: BitWrite,
     {
@@ -354,7 +363,7 @@ mod tests {
         assert_eq!(<() as EncodeableCustom>::worst_case_bits(&()), 0.0);
         // Zero payload bits still incurs coder-termination overhead, rounded
         // up to a whole byte.
-        assert_eq!(().encode_bytes().len(), 1);
+        assert_eq!(().encode_bytes().unwrap().len(), 1);
         assert_eq!(<() as Encodeable>::size_report().total_bytes(), 1);
     }
 }

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -215,13 +215,16 @@ where
     }
 
     fn report(config: &Self::Config) -> SizeReport {
-        // Every element has the same config, so compute the (possibly deep)
-        // element report once and clone it per index.
-        let element = T::report(config);
-        let children = (0..N)
-            .map(|i| element.clone().with_name(i.to_string()))
-            .collect();
-        SizeReport::product(children)
+        // A compact tree — one element *template* rather than one node per
+        // element (`N` can be large, and this report is built on every
+        // `decode_bytes` call). The node's bit total is computed
+        // arithmetically instead of summed from children, so it stays exact.
+        let element = T::report(config).with_name(format!("element (× {N})"));
+        SizeReport {
+            name: None,
+            bits: Self::worst_case_bits(config),
+            children: vec![element],
+        }
     }
 
     fn encode_with_config<W>(

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -92,6 +92,35 @@ where
     }
 }
 
+impl EncodeableCustom for () {
+    type Config = ();
+
+    fn weight(_config: &Self::Config) -> Weight {
+        // A single encodable value: the unit itself.
+        Weight::ONE
+    }
+
+    fn encode_with_config<W>(&self, _visitor: &mut EncodeVisitor<W>, _config: ()) -> io::Result<()>
+    where
+        W: BitWrite,
+    {
+        // Nothing to encode: `weight() == Weight::ONE`, so `()` costs zero
+        // bits on the wire.
+        Ok(())
+    }
+
+    fn decode_with_config<R>(
+        _visitor: &mut DecodeVisitor<R>,
+        _config: (),
+    ) -> Result<Self, DecodeError>
+    where
+        R: BitRead,
+        Self: Sized,
+    {
+        Ok(())
+    }
+}
+
 impl EncodeableCustom for f64 {
     type Config = FloatModel<f64>;
 
@@ -255,6 +284,7 @@ mod tests {
     #[test_case(&Option::Some(false))]
     #[test_case(&true)]
     #[test_case(&false)]
+    #[test_case(&())]
     fn round_trip<T>(input: &T)
     where
         T: Encodeable + std::fmt::Debug + PartialEq,
@@ -283,6 +313,7 @@ mod tests {
     #[test_case(&Option::Some(false), ())]
     #[test_case(&true, ())]
     #[test_case(&false, ())]
+    #[test_case(&(), ())]
     #[test_case(&450.0_f64, FloatModel::new(-10000.0..=10000.0, 1).unwrap())]
     #[test_case(&550.0_f64, FloatModel::new(-10000.0..=10000.0, 1).unwrap())]
     #[test_case(&-100.0_f64, FloatModel::new(-5000.0..=0.0, 0).unwrap())]
@@ -311,5 +342,16 @@ mod tests {
         let output = T::decode_with_config(&mut decoder, config).unwrap();
 
         assert_eq!(input, &output);
+    }
+
+    #[test]
+    #[allow(clippy::float_cmp)]
+    fn unit_type_costs_zero_bits() {
+        assert_eq!(<() as EncodeableCustom>::weight(&()), crate::Weight::ONE);
+        assert_eq!(<() as EncodeableCustom>::worst_case_bits(&()), 0.0);
+        // Zero payload bits still incurs coder-termination overhead, rounded
+        // up to a whole byte.
+        assert_eq!(().encode_bytes().len(), 1);
+        assert_eq!(<() as Encodeable>::size_report().total_bytes(), 1);
     }
 }

--- a/src/int.rs
+++ b/src/int.rs
@@ -64,6 +64,9 @@ where
 {
     /// Create a new [`IntModel`] over the given inclusive range.
     ///
+    /// Values outside this range are coerced to the nearest bound when
+    /// encoding, matching [`FloatModel`](crate::FloatModel).
+    ///
     /// # Errors
     ///
     /// Returns [`ModelError::InvertedBounds`] if `min > max`, or
@@ -100,13 +103,16 @@ where
     }
 
     /// The offset of `value` from `min`, as a `u128` in `0..denominator()`.
+    ///
+    /// Values outside `min..=max` are clamped to the nearest bound, matching
+    /// [`FloatModel`](crate::FloatModel)'s coercion semantics — so encoding
+    /// an out-of-range integer is lossy, never a panic or a violation of the
+    /// coder's interval contract.
     fn offset(&self, value: T) -> u128 {
-        let diff = to_i128(value) - to_i128(self.min);
-        // Encoding a value outside `min..=max` is a programming error (the
-        // symbol would not belong to this model); `IntModel` is only ever fed
-        // values of the concrete integer type it models, so this cannot
-        // actually go negative in practice.
-        u128::try_from(diff).expect("value is within the configured min..=max range")
+        let clamped = num_traits::clamp(value, self.min, self.max);
+        let diff = to_i128(clamped) - to_i128(self.min);
+        // `clamped >= min`, so the difference is non-negative.
+        u128::try_from(diff).expect("clamped value is at least min")
     }
 
     /// The inverse of [`IntModel::offset`].
@@ -276,5 +282,24 @@ mod tests {
     fn i8_default_spans_full_range() {
         let model = IntModel::<i8>::default();
         assert_eq!(model.denominator(), 256);
+    }
+
+    /// Out-of-range symbols clamp to the nearest bound instead of panicking
+    /// (below `min`) or emitting an interval past the denominator (above
+    /// `max`), which would violate the coder's model contract.
+    #[test]
+    fn out_of_range_symbols_clamp_to_bounds() {
+        let model = IntModel::new(0_u8..=10).unwrap();
+        assert_eq!(
+            Model::probability(&model, &11).unwrap(),
+            Model::probability(&model, &10).unwrap()
+        );
+        assert!(Model::probability(&model, &255).unwrap().end <= model.denominator());
+
+        let signed = IntModel::new(-5_i32..=5).unwrap();
+        assert_eq!(
+            Model::probability(&signed, &-100).unwrap(),
+            Model::probability(&signed, &-5).unwrap()
+        );
     }
 }

--- a/src/int.rs
+++ b/src/int.rs
@@ -15,8 +15,8 @@ use arithmetic_coding::one_shot;
 use num_traits::PrimInt;
 
 use crate::{
-    DecodeError, DecodeVisitor, EncodeVisitor, EncodeableCustom, MAX_DENOMINATOR, ModelError,
-    PRECISION, Weight,
+    DecodeError, DecodeVisitor, EncodeError, EncodeVisitor, EncodeableCustom, MAX_DENOMINATOR,
+    ModelError, PRECISION, Weight,
 };
 
 /// Convert a supported integer type to `i128`.
@@ -56,6 +56,7 @@ fn width<T: PrimInt>(min: T, max: T) -> u128 {
 pub struct IntModel<T> {
     min: T,
     max: T,
+    clamping: bool,
 }
 
 impl<T> IntModel<T>
@@ -64,8 +65,8 @@ where
 {
     /// Create a new [`IntModel`] over the given inclusive range.
     ///
-    /// Values outside this range are coerced to the nearest bound when
-    /// encoding, matching [`FloatModel`](crate::FloatModel).
+    /// Encoding a value outside this range is an [`EncodeError::OutOfRange`]
+    /// unless [clamping](IntModel::clamping) mode is enabled.
     ///
     /// # Errors
     ///
@@ -92,7 +93,45 @@ where
             });
         }
 
-        Ok(Self { min, max })
+        Ok(Self {
+            min,
+            max,
+            clamping: false,
+        })
+    }
+
+    /// Enable clamping mode: encoding a value outside `min..=max` clamps it
+    /// to the nearest bound instead of returning
+    /// [`EncodeError::OutOfRange`].
+    ///
+    /// Clamping is the right policy for naturally saturating sources
+    /// (sensor channels) and the wrong one for most everything else — hence
+    /// opt-in; see [`EncodeError`] for the reasoning.
+    #[must_use]
+    pub const fn clamping(mut self) -> Self {
+        self.clamping = true;
+        self
+    }
+
+    /// Validate `value` against this model's domain, returning the value that
+    /// will actually be encoded.
+    ///
+    /// # Errors
+    ///
+    /// [`EncodeError::OutOfRange`] for values outside `min..=max`, unless
+    /// [clamping](IntModel::clamping) mode is enabled.
+    fn admit(&self, value: T) -> Result<T, EncodeError> {
+        if value < self.min || value > self.max {
+            if self.clamping {
+                return Ok(num_traits::clamp(value, self.min, self.max));
+            }
+            return Err(EncodeError::OutOfRange {
+                value: format!("{value:?}"),
+                min: format!("{:?}", self.min),
+                max: format!("{:?}", self.max),
+            });
+        }
+        Ok(value)
     }
 
     /// The number of distinct values this model can encode — its
@@ -103,16 +142,13 @@ where
     }
 
     /// The offset of `value` from `min`, as a `u128` in `0..denominator()`.
-    ///
-    /// Values outside `min..=max` are clamped to the nearest bound, matching
-    /// [`FloatModel`](crate::FloatModel)'s coercion semantics — so encoding
-    /// an out-of-range integer is lossy, never a panic or a violation of the
-    /// coder's interval contract.
     fn offset(&self, value: T) -> u128 {
-        let clamped = num_traits::clamp(value, self.min, self.max);
-        let diff = to_i128(clamped) - to_i128(self.min);
-        // `clamped >= min`, so the difference is non-negative.
-        u128::try_from(diff).expect("clamped value is at least min")
+        debug_assert!(
+            value >= self.min && value <= self.max,
+            "offset is only called with admitted (in-range) values"
+        );
+        let diff = to_i128(value) - to_i128(self.min);
+        u128::try_from(diff).expect("admitted value is at least min")
     }
 
     /// The inverse of [`IntModel::offset`].
@@ -176,11 +212,13 @@ macro_rules! impl_int_leaf {
                 &self,
                 visitor: &mut EncodeVisitor<W>,
                 config: Self::Config,
-            ) -> std::io::Result<()>
+            ) -> Result<(), EncodeError>
             where
                 W: bitstream_io::BitWrite,
             {
-                visitor.encode_one(config, self)
+                let value = config.admit(*self)?;
+                visitor.encode_one(config, &value)?;
+                Ok(())
             }
 
             fn decode_with_config<R>(
@@ -284,22 +322,20 @@ mod tests {
         assert_eq!(model.denominator(), 256);
     }
 
-    /// Out-of-range symbols clamp to the nearest bound instead of panicking
-    /// (below `min`) or emitting an interval past the denominator (above
-    /// `max`), which would violate the coder's model contract.
+    /// Out-of-range values are an error by default and clamp only under the
+    /// explicit clamping opt-in.
     #[test]
-    fn out_of_range_symbols_clamp_to_bounds() {
-        let model = IntModel::new(0_u8..=10).unwrap();
-        assert_eq!(
-            Model::probability(&model, &11).unwrap(),
-            Model::probability(&model, &10).unwrap()
-        );
-        assert!(Model::probability(&model, &255).unwrap().end <= model.denominator());
+    fn admit_semantics() {
+        let strict = IntModel::new(0_u8..=10).unwrap();
+        assert_eq!(strict.admit(7).unwrap(), 7);
+        assert!(matches!(
+            strict.admit(11),
+            Err(crate::EncodeError::OutOfRange { .. })
+        ));
 
-        let signed = IntModel::new(-5_i32..=5).unwrap();
-        assert_eq!(
-            Model::probability(&signed, &-100).unwrap(),
-            Model::probability(&signed, &-5).unwrap()
-        );
+        let clamping = IntModel::new(-5_i32..=5).unwrap().clamping();
+        assert_eq!(clamping.admit(-100).unwrap(), -5);
+        assert_eq!(clamping.admit(100).unwrap(), 5);
+        assert_eq!(clamping.admit(3).unwrap(), 3);
     }
 }

--- a/src/int.rs
+++ b/src/int.rs
@@ -1,0 +1,280 @@
+//! A model for bounded integers (issue #3's sibling: the numeric leaf that
+//! [`crate::StringModel`]/[`crate::SeqModel`] build on for byte alphabets).
+//!
+//! [`IntModel<T>`] encodes a value of an integer type `T` uniformly over an
+//! inclusive `min..=max` range: weight `max − min + 1`, one symbol per value.
+//! It is implemented for every primitive integer type from `u8`/`i8` up to
+//! `u64`/`i64`.
+
+use std::{
+    convert::Infallible,
+    ops::{Range, RangeInclusive},
+};
+
+use arithmetic_coding::one_shot;
+use num_traits::PrimInt;
+
+use crate::{
+    DecodeError, DecodeVisitor, EncodeVisitor, EncodeableCustom, MAX_DENOMINATOR, ModelError,
+    PRECISION, Weight,
+};
+
+/// Convert a supported integer type to `i128`.
+///
+/// Every type this module supports (`u8..=u64`, `i8..=i64`) fits losslessly
+/// in `i128`, so this never fails in practice.
+fn to_i128<T: PrimInt>(value: T) -> i128 {
+    num_traits::ToPrimitive::to_i128(&value)
+        .expect("every type IntModel supports fits losslessly in i128")
+}
+
+/// Convert an `i128` back to a supported integer type.
+///
+/// Callers must ensure `value` is within `T`'s range; [`IntModel`] only ever
+/// calls this with offsets bounded by its own `min..=max`, so the conversion
+/// always succeeds.
+fn from_i128<T: PrimInt>(value: i128) -> T {
+    <T as num_traits::NumCast>::from(value)
+        .expect("value is within the configured range, which is within T's range")
+}
+
+/// The number of distinct values in `min..=max`, as a `u128`.
+fn width<T: PrimInt>(min: T, max: T) -> u128 {
+    let diff = to_i128(max) - to_i128(min);
+    // `max >= min` is checked by every caller before this runs, so `diff` is
+    // never negative.
+    u128::try_from(diff).expect("max >= min, so the difference is non-negative")
+}
+
+/// A [`Model`](arithmetic_coding::one_shot::Model) which encodes and decodes
+/// a bounded integer, uniform over `min..=max`.
+///
+/// The weight (see [`crate::Weight`]) of an `IntModel` is `max − min + 1`:
+/// every value in the range is equally likely and costs the same fractional
+/// number of bits.
+#[derive(Clone, Copy, Debug)]
+pub struct IntModel<T> {
+    min: T,
+    max: T,
+}
+
+impl<T> IntModel<T>
+where
+    T: PrimInt + std::fmt::Debug,
+{
+    /// Create a new [`IntModel`] over the given inclusive range.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelError::InvertedBounds`] if `min > max`, or
+    /// [`ModelError::DenominatorTooLarge`] if the number of distinguishable
+    /// values in the range (`max − min + 1`) would exceed
+    /// [`MAX_DENOMINATOR`](crate::MAX_DENOMINATOR).
+    pub fn new(range: RangeInclusive<T>) -> Result<Self, ModelError> {
+        let min = *range.start();
+        let max = *range.end();
+
+        if min > max {
+            return Err(ModelError::InvertedBounds);
+        }
+
+        let width = width(min, max);
+        // `denominator = width + 1`; reject before the `+ 1` can overflow or
+        // exceed the bound (mirrors `FloatModel::new`).
+        if width >= MAX_DENOMINATOR {
+            return Err(ModelError::DenominatorTooLarge {
+                denominator: width.saturating_add(1),
+                max: MAX_DENOMINATOR,
+                precision: PRECISION,
+            });
+        }
+
+        Ok(Self { min, max })
+    }
+
+    /// The number of distinct values this model can encode — its
+    /// [`Weight`](crate::Weight): `max − min + 1`.
+    #[must_use]
+    pub fn denominator(&self) -> u128 {
+        width(self.min, self.max) + 1
+    }
+
+    /// The offset of `value` from `min`, as a `u128` in `0..denominator()`.
+    fn offset(&self, value: T) -> u128 {
+        let diff = to_i128(value) - to_i128(self.min);
+        // Encoding a value outside `min..=max` is a programming error (the
+        // symbol would not belong to this model); `IntModel` is only ever fed
+        // values of the concrete integer type it models, so this cannot
+        // actually go negative in practice.
+        u128::try_from(diff).expect("value is within the configured min..=max range")
+    }
+
+    /// The inverse of [`IntModel::offset`].
+    fn unscale(&self, offset: u128) -> T {
+        let offset = i128::try_from(offset).expect("offset is bounded by the denominator");
+        from_i128(to_i128(self.min) + offset)
+    }
+}
+
+impl<T> one_shot::Model for IntModel<T>
+where
+    T: PrimInt + std::fmt::Debug,
+{
+    type B = u128;
+    type Symbol = T;
+    type ValueError = Infallible;
+
+    fn probability(&self, symbol: &Self::Symbol) -> Result<Range<Self::B>, Self::ValueError> {
+        let offset = self.offset(*symbol);
+        #[allow(clippy::range_plus_one)]
+        Ok(offset..offset + 1)
+    }
+
+    fn max_denominator(&self) -> Self::B {
+        self.denominator()
+    }
+
+    fn symbol(&self, value: Self::B) -> Self::Symbol {
+        self.unscale(value)
+    }
+}
+
+/// Implement [`EncodeableCustom`] for a primitive integer type `$t`, whose
+/// config is `IntModel<$t>`.
+///
+/// The `@default` variant additionally gives the type a [`Default`]
+/// `IntModel` spanning its entire native range (`$t::MIN..=$t::MAX`), which
+/// is only safe for types whose full range fits within
+/// [`MAX_DENOMINATOR`](crate::MAX_DENOMINATOR) — `u64`/`i64` do not (their
+/// full-range denominator, `2^64`, exceeds the ~`2^62` bound), so those two
+/// types require an explicit [`IntModel::new`] range and have no `Default`.
+macro_rules! impl_int_leaf {
+    (@default $t:ty) => {
+        impl Default for IntModel<$t> {
+            fn default() -> Self {
+                Self::new(<$t>::MIN..=<$t>::MAX)
+                    .expect("the full range of this type fits within MAX_DENOMINATOR")
+            }
+        }
+        impl_int_leaf!(@no_default $t);
+    };
+    (@no_default $t:ty) => {
+        impl EncodeableCustom for $t {
+            type Config = IntModel<$t>;
+
+            fn weight(config: &Self::Config) -> Weight {
+                Weight::new(config.denominator())
+            }
+
+            fn encode_with_config<W>(
+                &self,
+                visitor: &mut EncodeVisitor<W>,
+                config: Self::Config,
+            ) -> std::io::Result<()>
+            where
+                W: bitstream_io::BitWrite,
+            {
+                visitor.encode_one(config, self)
+            }
+
+            fn decode_with_config<R>(
+                visitor: &mut DecodeVisitor<R>,
+                config: Self::Config,
+            ) -> Result<Self, DecodeError>
+            where
+                R: bitstream_io::BitRead,
+                Self: Sized,
+            {
+                visitor.decode_one(config)
+            }
+        }
+    };
+}
+
+impl_int_leaf!(@default u8);
+impl_int_leaf!(@default u16);
+impl_int_leaf!(@default u32);
+impl_int_leaf!(@default i8);
+impl_int_leaf!(@default i16);
+impl_int_leaf!(@default i32);
+// `u64`/`i64` have no `Default` `IntModel`: their full native range's
+// denominator (`2^64`) exceeds `MAX_DENOMINATOR` (`~2^62`), so callers must
+// supply an explicit bounded range.
+impl_int_leaf!(@no_default u64);
+impl_int_leaf!(@no_default i64);
+
+#[cfg(test)]
+mod tests {
+    use arithmetic_coding::one_shot::Model;
+    use test_case::test_case;
+
+    use super::IntModel;
+    use crate::ModelError;
+
+    #[test]
+    fn denominator() {
+        let model = IntModel::new(-5_i32..=5).unwrap();
+        assert_eq!(model.denominator(), 11);
+    }
+
+    #[test_case(0 => 0..1)]
+    #[test_case(5 => 5..6)]
+    #[test_case(-5 => -5..-4; "negative")]
+    fn probability(input: i32) -> std::ops::Range<i32> {
+        let model = IntModel::new(-5_i32..=5).unwrap();
+        // Translate the returned `u128` interval back to an `i32` range for a
+        // readable assertion.
+        let range = model.probability(&input).unwrap();
+        #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+        let start = range.start as i32 - 5;
+        #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+        let end = range.end as i32 - 5;
+        start..end
+    }
+
+    #[test]
+    fn round_trips_symbol() {
+        let model = IntModel::new(-1000_i32..=1000).unwrap();
+        for value in [-1000, -1, 0, 1, 1000] {
+            let range = model.probability(&value).unwrap();
+            assert_eq!(model.symbol(range.start), value);
+        }
+    }
+
+    #[test]
+    fn rejects_inverted_bounds() {
+        let min = 5_i32;
+        let max = -5_i32;
+        assert_eq!(
+            IntModel::new(min..=max).unwrap_err(),
+            ModelError::InvertedBounds
+        );
+    }
+
+    #[test]
+    fn rejects_oversized_denominator() {
+        let err = IntModel::new(0_i64..=i64::MAX).unwrap_err();
+        assert!(matches!(err, ModelError::DenominatorTooLarge { .. }));
+    }
+
+    #[test]
+    fn accepts_full_u64_minus_epsilon() {
+        // The largest range whose weight (width + 1) is still <=
+        // MAX_DENOMINATOR.
+        let max_denominator = u64::try_from(crate::MAX_DENOMINATOR).unwrap();
+        assert!(IntModel::new(0_u64..=(max_denominator - 1)).is_ok());
+        assert!(IntModel::new(0_u64..=max_denominator).is_err());
+    }
+
+    #[test]
+    fn u8_default_spans_full_range() {
+        let model = IntModel::<u8>::default();
+        assert_eq!(model.denominator(), 256);
+    }
+
+    #[test]
+    fn i8_default_spans_full_range() {
+        let model = IntModel::<i8>::default();
+        assert_eq!(model.denominator(), 256);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,17 +19,25 @@ mod encodeable_custom;
 mod error;
 mod float;
 mod impls;
+mod int;
+mod model_error;
 mod report;
+mod seq;
+mod string;
 mod visitor;
 mod weight;
 
 pub use encodeable::Encodeable;
 pub use encodeable_custom::EncodeableCustom;
 pub use error::DecodeError;
-pub use float::{FloatModel, ModelError};
+pub use float::FloatModel;
 pub use impls::{one_shot::OneShot, weighted::WeightedModel};
+pub use int::IntModel;
 pub use minnow_derive::Encodeable;
+pub use model_error::ModelError;
 pub use report::{SizeReport, TERMINATION_BITS};
+pub use seq::SeqModel;
+pub use string::StringModel;
 pub use visitor::{DecodeVisitor, EncodeVisitor};
 pub use weight::Weight;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ mod weight;
 
 pub use encodeable::Encodeable;
 pub use encodeable_custom::EncodeableCustom;
-pub use error::DecodeError;
+pub use error::{DecodeError, EncodeError};
 pub use float::FloatModel;
 pub use impls::{one_shot::OneShot, weighted::WeightedModel};
 pub use int::IntModel;

--- a/src/model_error.rs
+++ b/src/model_error.rs
@@ -1,0 +1,38 @@
+//! The shared error type for fallible leaf-model constructors.
+
+/// An error returned when a model cannot be constructed because its
+/// parameters violate the arithmetic coder's precision invariant (see
+/// [`MAX_DENOMINATOR`](crate::MAX_DENOMINATOR)) or are otherwise invalid.
+///
+/// Every leaf model with a fallible constructor
+/// ([`FloatModel::new`](crate::FloatModel::new),
+/// [`IntModel::new`](crate::IntModel::new),
+/// [`StringModel::new`](crate::StringModel::new)) shares this one error type,
+/// so callers only need to handle a single error shape regardless of which
+/// model they are building.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum ModelError {
+    /// One or both of the supplied bounds was `NaN` or infinite.
+    #[error("model bounds must be finite (neither NaN nor infinite)")]
+    NonFiniteBounds,
+
+    /// The lower bound was greater than the upper bound.
+    #[error("model lower bound must not exceed the upper bound")]
+    InvertedBounds,
+
+    /// The resulting denominator exceeds
+    /// [`MAX_DENOMINATOR`](crate::MAX_DENOMINATOR).
+    #[error(
+        "model denominator ({denominator}) exceeds the maximum ({max}) permitted at precision \
+         {precision}; narrow the range or reduce the precision"
+    )]
+    DenominatorTooLarge {
+        /// The denominator that was requested.
+        denominator: u128,
+        /// The maximum permissible denominator.
+        max: u128,
+        /// The arithmetic coder precision in bits.
+        precision: u32,
+    },
+}

--- a/src/seq.rs
+++ b/src/seq.rs
@@ -150,17 +150,19 @@ where
     }
 
     fn report(config: &Self::Config) -> SizeReport {
-        // Materialises one child node per possible element slot (`max_len` of
-        // them), matching `[T; N]`'s array report. This is `O(max_len)` in
-        // both time and memory, so it is only practical for reasonably small
-        // bounds — a `max_len` in the billions would exhaust memory here even
-        // though `weight`/`worst_case_bits` stay cheap.
+        // A compact tree — a `length` leaf plus one element *template* —
+        // rather than one node per slot: `max_len` may be in the billions,
+        // and this report is built on every `decode_bytes` call. The node's
+        // bit total is computed arithmetically instead of summed from
+        // children, so it stays exact.
         let length_leaf = SizeReport::leaf(length_bits(config.max_len)).with_name("length");
-        let element = T::report(&config.elem);
-        let mut children = Vec::with_capacity(config.max_len as usize + 1);
-        children.push(length_leaf);
-        children.extend((0..config.max_len).map(|i| element.clone().with_name(i.to_string())));
-        SizeReport::product(children)
+        let element =
+            T::report(&config.elem).with_name(format!("element (worst case × {})", config.max_len));
+        SizeReport {
+            name: None,
+            bits: Self::worst_case_bits(config),
+            children: vec![length_leaf, element],
+        }
     }
 
     fn encode_with_config<W>(
@@ -319,5 +321,24 @@ mod tests {
         let mut encoder = crate::EncodeVisitor::new(crate::PRECISION, &mut writer);
         let err = value.encode_with_config(&mut encoder, config).unwrap_err();
         assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+    }
+
+    /// The report (and the decode length check that used to build it) must
+    /// stay `O(1)` in `max_len`: a huge but valid bound must not materialise
+    /// one node per element slot.
+    #[test]
+    fn report_is_compact_for_huge_bounds() {
+        let config = SeqModel {
+            max_len: u32::MAX,
+            elem: (),
+        };
+        let report = <Vec<bool>>::report(&config);
+        // One `length` leaf plus one element template, regardless of the bound.
+        assert_eq!(report.children.len(), 2);
+
+        // The pre-decode length check runs without touching the report tree;
+        // empty input is simply outside the schema's length window.
+        let err = <Vec<bool>>::decode_bytes_with_config(&[], config).unwrap_err();
+        assert!(matches!(err, crate::DecodeError::Length { .. }));
     }
 }

--- a/src/seq.rs
+++ b/src/seq.rs
@@ -47,12 +47,14 @@
 //! [`crate::DecodeError::Length`]) is wide rather than pinned to an exact
 //! value — it still never rejects a genuinely valid encoding.
 
-use std::{convert::Infallible, io, ops::Range};
+use std::{convert::Infallible, ops::Range};
 
 use arithmetic_coding::one_shot;
 use bitstream_io::{BitRead, BitWrite};
 
-use crate::{DecodeError, DecodeVisitor, EncodeVisitor, EncodeableCustom, SizeReport, Weight};
+use crate::{
+    DecodeError, DecodeVisitor, EncodeError, EncodeVisitor, EncodeableCustom, SizeReport, Weight,
+};
 
 /// A uniform one-shot model over `0..=max_len` — the length prefix shared by
 /// [`SeqModel`]/[`crate::StringModel`].
@@ -169,19 +171,18 @@ where
         &self,
         visitor: &mut EncodeVisitor<W>,
         config: Self::Config,
-    ) -> io::Result<()>
+    ) -> Result<(), EncodeError>
     where
         W: BitWrite,
     {
         let len = self.len();
         if len > config.max_len as usize {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                format!(
-                    "cannot encode a {len}-element Vec: exceeds the configured max_len ({})",
-                    config.max_len
-                ),
-            ));
+            // No clamping mode for sequences: truncation would silently
+            // drop elements, which is not a nearest-value projection.
+            return Err(EncodeError::TooLong {
+                len,
+                max_len: config.max_len,
+            });
         }
         // `len <= config.max_len`, a `u32`, so this cast cannot truncate.
         #[allow(clippy::cast_possible_truncation)]
@@ -287,7 +288,7 @@ mod tests {
             elem: (),
         };
         let empty: Vec<bool> = Vec::new();
-        let bytes = empty.encode_bytes_with_config(config);
+        let bytes = empty.encode_bytes_with_config(config).unwrap();
 
         // The empty vector is the cheapest value: just the length prefix,
         // `log2(11)` bits.
@@ -304,7 +305,7 @@ mod tests {
         };
         for len in 0..=5 {
             let value: Vec<bool> = vec![true; len];
-            let bytes = value.encode_bytes_with_config(config);
+            let bytes = value.encode_bytes_with_config(config).unwrap();
             let decoded = <Vec<bool>>::decode_bytes_with_config(&bytes, config).unwrap();
             assert_eq!(decoded, value);
         }
@@ -320,7 +321,7 @@ mod tests {
         let mut writer = bitstream_io::BitWriter::endian(Vec::new(), bitstream_io::BigEndian);
         let mut encoder = crate::EncodeVisitor::new(crate::PRECISION, &mut writer);
         let err = value.encode_with_config(&mut encoder, config).unwrap_err();
-        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+        assert!(matches!(err, crate::EncodeError::TooLong { .. }));
     }
 
     /// The report (and the decode length check that used to build it) must

--- a/src/seq.rs
+++ b/src/seq.rs
@@ -1,0 +1,323 @@
+//! A length-prefixed model for bounded sequences (`Vec<T>`, issue #5), and the
+//! byte-sequence machinery [`crate::StringModel`] builds on.
+//!
+//! # Wire format
+//!
+//! A sequence of at most `max_len` elements is encoded as:
+//!
+//! 1. a **uniform** length symbol over `0..=max_len` (`max_len + 1` equally
+//!    likely values), costing exactly `log₂(max_len + 1)` bits;
+//! 2. that many elements, each encoded with the shared `elem` config.
+//!
+//! # The math
+//!
+//! Per the cardinality semiring (see [`crate::Weight`]), a bounded sequence is
+//! a sum-of-products over its possible lengths:
+//!
+//! ```text
+//! W(Vec<T>) = Σ_{k=0}^{L} W(T)^k        (saturating)
+//! ```
+//!
+//! and the bit-accounting methods follow directly from the uniform length
+//! prefix:
+//!
+//! ```text
+//! worst_case_bits = log₂(L + 1) + L · worst_case_bits(T)   (the full vector)
+//! best_case_bits  = log₂(L + 1)                            (the empty vector)
+//! ```
+//!
+//! # Deliberate design decision: uniform, not cardinality-weighted, length
+//!
+//! A *cardinality*-weighted length prefix (interval width `W(T)^k` for length
+//! `k`, à la [`crate::WeightedModel`]) would make every value of `Vec<T>` cost
+//! exactly `log₂ W(Vec<T>)` bits — matching the minimax-optimal scheme used
+//! for enums (see the crate documentation). But it would also make the
+//! **empty** vector cost almost as much as the **longest** one, since nearly
+//! all of `W(Vec<T>)`'s cardinality lives in the `k = L` term. That defeats
+//! the purpose of a variable-length field: short values should be cheap. The
+//! uniform length prefix trades a worst-case redundancy of
+//! `log₂(L + 1) − log₂(A / (A − 1))` bits (where `A = W(T)`) for exactly that
+//! property — a short vector costs `log₂(L + 1) + k · log₂ A`, not
+//! `log₂ W(Vec<T>)` regardless of `k`. A cardinality-weighted opt-in can be
+//! added later; it is not implemented here.
+//!
+//! Because the length prefix is uniform, `Vec<T>`'s `best_case_bits` and
+//! `worst_case_bits` genuinely differ (unlike every uniformly-weighted
+//! fixed-size type), so the pre-decode length window (see
+//! [`crate::DecodeError::Length`]) is wide rather than pinned to an exact
+//! value — it still never rejects a genuinely valid encoding.
+
+use std::{convert::Infallible, io, ops::Range};
+
+use arithmetic_coding::one_shot;
+use bitstream_io::{BitRead, BitWrite};
+
+use crate::{DecodeError, DecodeVisitor, EncodeVisitor, EncodeableCustom, SizeReport, Weight};
+
+/// A uniform one-shot model over `0..=max_len` — the length prefix shared by
+/// [`SeqModel`]/[`crate::StringModel`].
+///
+/// This is a runtime-sized sibling of [`crate::OneShot`] (which needs its
+/// symbol count as a `const` generic); `max_len` is only known at runtime
+/// here, since it comes from a field's config rather than the type itself.
+#[derive(Debug, Clone, Copy)]
+struct LengthModel {
+    max_len: u32,
+}
+
+impl one_shot::Model for LengthModel {
+    type B = u128;
+    type Symbol = u32;
+    type ValueError = Infallible;
+
+    fn probability(&self, symbol: &Self::Symbol) -> Result<Range<Self::B>, Self::ValueError> {
+        let value = u128::from(*symbol);
+        #[allow(clippy::range_plus_one)]
+        Ok(value..value + 1)
+    }
+
+    fn max_denominator(&self) -> Self::B {
+        u128::from(self.max_len) + 1
+    }
+
+    fn symbol(&self, value: Self::B) -> Self::Symbol {
+        // `value < max_denominator() = max_len + 1 <= u32::MAX + 1`, but the
+        // arithmetic decoder only ever produces `value` within that bound, so
+        // this always fits `u32`.
+        u32::try_from(value).unwrap_or(u32::MAX)
+    }
+}
+
+/// The configuration for a bounded sequence: a maximum length and the
+/// per-element configuration.
+///
+/// See the module documentation for the wire format and the weight/bit-cost
+/// formulas.
+#[derive(Debug, Clone, Copy)]
+pub struct SeqModel<C> {
+    /// The maximum number of elements the sequence may contain.
+    pub max_len: u32,
+    /// The configuration shared by every element.
+    pub elem: C,
+}
+
+impl<T, C> EncodeableCustom for Vec<T>
+where
+    T: EncodeableCustom<Config = C>,
+    C: Clone,
+{
+    type Config = SeqModel<C>;
+
+    fn weight(config: &Self::Config) -> Weight {
+        let elem_weight = T::weight(&config.elem);
+
+        // Closed form when every element weighs exactly one (e.g. a `Vec` of
+        // a unit type): every term of the sum is `1`, so the total is simply
+        // `max_len + 1`. Without this, a huge `max_len` with `elem_weight ==
+        // 1` would never trip the saturation short-circuit below (the sum
+        // grows by exactly 1 each iteration, so it would take `u128::MAX`
+        // iterations to saturate) and the loop would never terminate in
+        // practice.
+        if elem_weight == Weight::ONE {
+            return Weight::new(u128::from(config.max_len) + 1);
+        }
+
+        // General case: Σ_{k=0}^{max_len} elem_weight^k, saturating. This
+        // loop always terminates quickly regardless of `max_len`: once
+        // `elem_weight > 1`, the running total saturates (or the running
+        // power underflows to zero, for `elem_weight == 0`) within at most a
+        // few hundred iterations.
+        let mut total = Weight::ZERO;
+        let mut power = Weight::ONE;
+        for _ in 0..=config.max_len {
+            total = total + power;
+            if total.is_saturated() || power == Weight::ZERO {
+                return total;
+            }
+            power = power * elem_weight;
+        }
+        total
+    }
+
+    fn worst_case_bits(config: &Self::Config) -> f64 {
+        let length_bits = length_bits(config.max_len);
+        f64::from(config.max_len).mul_add(T::worst_case_bits(&config.elem), length_bits)
+    }
+
+    fn best_case_bits(config: &Self::Config) -> f64 {
+        // The cheapest value is the empty vector: just the length prefix.
+        length_bits(config.max_len)
+    }
+
+    fn report(config: &Self::Config) -> SizeReport {
+        // Materialises one child node per possible element slot (`max_len` of
+        // them), matching `[T; N]`'s array report. This is `O(max_len)` in
+        // both time and memory, so it is only practical for reasonably small
+        // bounds — a `max_len` in the billions would exhaust memory here even
+        // though `weight`/`worst_case_bits` stay cheap.
+        let length_leaf = SizeReport::leaf(length_bits(config.max_len)).with_name("length");
+        let element = T::report(&config.elem);
+        let mut children = Vec::with_capacity(config.max_len as usize + 1);
+        children.push(length_leaf);
+        children.extend((0..config.max_len).map(|i| element.clone().with_name(i.to_string())));
+        SizeReport::product(children)
+    }
+
+    fn encode_with_config<W>(
+        &self,
+        visitor: &mut EncodeVisitor<W>,
+        config: Self::Config,
+    ) -> io::Result<()>
+    where
+        W: BitWrite,
+    {
+        let len = self.len();
+        if len > config.max_len as usize {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "cannot encode a {len}-element Vec: exceeds the configured max_len ({})",
+                    config.max_len
+                ),
+            ));
+        }
+        // `len <= config.max_len`, a `u32`, so this cast cannot truncate.
+        #[allow(clippy::cast_possible_truncation)]
+        let len_symbol = len as u32;
+
+        visitor.encode_one(
+            LengthModel {
+                max_len: config.max_len,
+            },
+            &len_symbol,
+        )?;
+        for item in self {
+            item.encode_with_config(visitor, config.elem.clone())?;
+        }
+        Ok(())
+    }
+
+    fn decode_with_config<R>(
+        visitor: &mut DecodeVisitor<R>,
+        config: Self::Config,
+    ) -> Result<Self, DecodeError>
+    where
+        R: BitRead,
+        Self: Sized,
+    {
+        let len = visitor.decode_one(LengthModel {
+            max_len: config.max_len,
+        })?;
+        // Defensive: the length model's own denominator (`max_len + 1`) means
+        // the arithmetic decoder can never actually produce a value outside
+        // `0..=max_len`, but a corrupt stream must never be trusted to
+        // preserve that invariant, and `Vec::with_capacity` below must never
+        // be handed an unvalidated, attacker-controlled length.
+        if len > config.max_len {
+            return Err(DecodeError::InvalidSymbol {
+                symbol: u128::from(len),
+            });
+        }
+
+        let mut result = Vec::with_capacity(len as usize);
+        for _ in 0..len {
+            result.push(T::decode_with_config(visitor, config.elem.clone())?);
+        }
+        Ok(result)
+    }
+}
+
+/// `log₂(max_len + 1)`, computed without risking `u32` overflow (`max_len`
+/// may be `u32::MAX`).
+fn length_bits(max_len: u32) -> f64 {
+    (f64::from(max_len) + 1.0).log2()
+}
+
+#[cfg(test)]
+mod tests {
+    use arithmetic_coding::one_shot::Model;
+
+    use super::{LengthModel, SeqModel};
+    use crate::{EncodeableCustom, Weight};
+
+    #[test]
+    fn length_model_covers_full_range() {
+        let model = LengthModel { max_len: 5 };
+        assert_eq!(model.max_denominator(), 6);
+        for symbol in 0..=5_u32 {
+            let range = model.probability(&symbol).unwrap();
+            assert_eq!(model.symbol(range.start), symbol);
+        }
+    }
+
+    #[test]
+    fn weight_matches_geometric_sum() {
+        // elem weight 2 (bool), max_len 3: 1 + 2 + 4 + 8 = 15.
+        let config = SeqModel {
+            max_len: 3,
+            elem: (),
+        };
+        assert_eq!(
+            <Vec<bool> as EncodeableCustom>::weight(&config),
+            Weight::new(15)
+        );
+    }
+
+    #[test]
+    fn weight_with_unit_element_is_length_plus_one() {
+        // elem weight 1 (unit type): every length costs the same, so the sum
+        // is exactly max_len + 1. Also exercises that a huge max_len doesn't
+        // hang: this would need u32::MAX iterations without the closed form.
+        let config = SeqModel {
+            max_len: u32::MAX,
+            elem: (),
+        };
+        assert_eq!(
+            <Vec<()> as EncodeableCustom>::weight(&config),
+            Weight::new(u128::from(u32::MAX) + 1)
+        );
+    }
+
+    #[test]
+    fn best_case_matches_empty_vec() {
+        let config = SeqModel {
+            max_len: 10,
+            elem: (),
+        };
+        let empty: Vec<bool> = Vec::new();
+        let bytes = empty.encode_bytes_with_config(config);
+
+        // The empty vector is the cheapest value: just the length prefix,
+        // `log2(11)` bits.
+        let best_bits = <Vec<bool> as EncodeableCustom>::best_case_bits(&config);
+        assert!((best_bits - 11_f64.log2()).abs() < 1e-9);
+        assert!(bytes.len() <= <Vec<bool> as EncodeableCustom>::report(&config).total_bytes());
+    }
+
+    #[test]
+    fn round_trips() {
+        let config = SeqModel {
+            max_len: 5,
+            elem: (),
+        };
+        for len in 0..=5 {
+            let value: Vec<bool> = vec![true; len];
+            let bytes = value.encode_bytes_with_config(config);
+            let decoded = <Vec<bool>>::decode_bytes_with_config(&bytes, config).unwrap();
+            assert_eq!(decoded, value);
+        }
+    }
+
+    #[test]
+    fn encoding_over_max_len_is_rejected() {
+        let config = SeqModel {
+            max_len: 2,
+            elem: (),
+        };
+        let value: Vec<bool> = vec![true; 3];
+        let mut writer = bitstream_io::BitWriter::endian(Vec::new(), bitstream_io::BigEndian);
+        let mut encoder = crate::EncodeVisitor::new(crate::PRECISION, &mut writer);
+        let err = value.encode_with_config(&mut encoder, config).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+    }
+}

--- a/src/string.rs
+++ b/src/string.rs
@@ -1,12 +1,10 @@
 //! A model for `String` (issue #3): a bounded sequence of UTF-8 bytes.
 
-use std::io;
-
 use bitstream_io::{BitRead, BitWrite};
 
 use crate::{
-    DecodeError, DecodeVisitor, EncodeVisitor, EncodeableCustom, IntModel, ModelError, SeqModel,
-    SizeReport, Weight,
+    DecodeError, DecodeVisitor, EncodeError, EncodeVisitor, EncodeableCustom, IntModel, ModelError,
+    SeqModel, SizeReport, Weight,
 };
 
 /// The configuration for a [`String`] field: a maximum length **in bytes**.
@@ -83,7 +81,7 @@ impl EncodeableCustom for String {
         &self,
         visitor: &mut EncodeVisitor<W>,
         config: Self::Config,
-    ) -> io::Result<()>
+    ) -> Result<(), EncodeError>
     where
         W: BitWrite,
     {
@@ -125,7 +123,7 @@ mod tests {
             "the quick brown fox",
         ] {
             let config = StringModel::new(64).unwrap();
-            let bytes = s.to_string().encode_bytes_with_config(config);
+            let bytes = s.to_string().encode_bytes_with_config(config).unwrap();
             let decoded = String::decode_bytes_with_config(&bytes, config).unwrap();
             assert_eq!(decoded, s);
         }
@@ -136,14 +134,14 @@ mod tests {
         let config = StringModel::new(5).unwrap();
 
         let empty = String::new();
-        let bytes = empty.encode_bytes_with_config(config);
+        let bytes = empty.encode_bytes_with_config(config).unwrap();
         assert_eq!(
             String::decode_bytes_with_config(&bytes, config).unwrap(),
             empty
         );
 
         let max = "abcde".to_string();
-        let bytes = max.encode_bytes_with_config(config);
+        let bytes = max.encode_bytes_with_config(config).unwrap();
         assert_eq!(
             String::decode_bytes_with_config(&bytes, config).unwrap(),
             max
@@ -159,7 +157,7 @@ mod tests {
         let err = too_long
             .encode_with_config(&mut encoder, config)
             .unwrap_err();
-        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+        assert!(matches!(err, crate::EncodeError::TooLong { .. }));
     }
 
     #[test]
@@ -170,10 +168,12 @@ mod tests {
         // cleanly.
         let config = StringModel::new(4).unwrap();
         let invalid_bytes: Vec<u8> = vec![0xff, 0xfe];
-        let bytes = invalid_bytes.encode_bytes_with_config(crate::SeqModel {
-            max_len: u32::try_from(config.max_length()).unwrap(),
-            elem: crate::IntModel::<u8>::default(),
-        });
+        let bytes = invalid_bytes
+            .encode_bytes_with_config(crate::SeqModel {
+                max_len: u32::try_from(config.max_length()).unwrap(),
+                elem: crate::IntModel::<u8>::default(),
+            })
+            .unwrap();
 
         let err = String::decode_bytes_with_config(&bytes, config).unwrap_err();
         assert!(matches!(err, DecodeError::InvalidUtf8(_)));

--- a/src/string.rs
+++ b/src/string.rs
@@ -1,0 +1,187 @@
+//! A model for `String` (issue #3): a bounded sequence of UTF-8 bytes.
+
+use std::io;
+
+use bitstream_io::{BitRead, BitWrite};
+
+use crate::{
+    DecodeError, DecodeVisitor, EncodeVisitor, EncodeableCustom, IntModel, ModelError, SeqModel,
+    SizeReport, Weight,
+};
+
+/// The configuration for a [`String`] field: a maximum length **in bytes**.
+///
+/// `String` is modelled as a bounded sequence of bytes (see
+/// [`crate::SeqModel`]), each byte uniform over all 256 values — i.e.
+/// `StringModel` is exactly `SeqModel<IntModel<u8>>` under the hood, with the
+/// byte model fixed to its full-range [`Default`]. Restricting the alphabet
+/// (e.g. printable ASCII, à la DCCL) would shrink the per-byte cost below 8
+/// bits, but is not implemented here — a documented follow-up.
+///
+/// Every value round-trips as bytes; not every byte sequence is valid UTF-8,
+/// so decoding a corrupt stream can fail with
+/// [`DecodeError::InvalidUtf8`](crate::DecodeError::InvalidUtf8) rather than
+/// panicking.
+#[derive(Debug, Clone, Copy)]
+pub struct StringModel {
+    bytes: SeqModel<IntModel<u8>>,
+}
+
+impl StringModel {
+    /// Create a new [`StringModel`] with the given maximum length, in bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelError::DenominatorTooLarge`] if `max_length` does not
+    /// fit in a `u32` (the length prefix's underlying representation — see
+    /// [`SeqModel::max_len`](crate::SeqModel)); a `u32`-bounded length always
+    /// stays comfortably within
+    /// [`MAX_DENOMINATOR`](crate::MAX_DENOMINATOR), so this is the only way
+    /// construction can fail.
+    pub fn new(max_length: usize) -> Result<Self, ModelError> {
+        let max_len = u32::try_from(max_length).map_err(|_| ModelError::DenominatorTooLarge {
+            denominator: u128::try_from(max_length).unwrap_or(u128::MAX),
+            max: u128::from(u32::MAX),
+            precision: crate::PRECISION,
+        })?;
+        Ok(Self {
+            bytes: SeqModel {
+                max_len,
+                elem: IntModel::<u8>::default(),
+            },
+        })
+    }
+
+    /// The maximum length, in bytes, a [`String`] configured with this model
+    /// may occupy.
+    #[must_use]
+    pub fn max_length(&self) -> usize {
+        self.bytes.max_len as usize
+    }
+}
+
+impl EncodeableCustom for String {
+    type Config = StringModel;
+
+    fn weight(config: &Self::Config) -> Weight {
+        <Vec<u8> as EncodeableCustom>::weight(&config.bytes)
+    }
+
+    fn worst_case_bits(config: &Self::Config) -> f64 {
+        <Vec<u8> as EncodeableCustom>::worst_case_bits(&config.bytes)
+    }
+
+    fn best_case_bits(config: &Self::Config) -> f64 {
+        <Vec<u8> as EncodeableCustom>::best_case_bits(&config.bytes)
+    }
+
+    fn report(config: &Self::Config) -> SizeReport {
+        <Vec<u8> as EncodeableCustom>::report(&config.bytes)
+    }
+
+    fn encode_with_config<W>(
+        &self,
+        visitor: &mut EncodeVisitor<W>,
+        config: Self::Config,
+    ) -> io::Result<()>
+    where
+        W: BitWrite,
+    {
+        let bytes = self.as_bytes().to_vec();
+        bytes.encode_with_config(visitor, config.bytes)
+    }
+
+    fn decode_with_config<R>(
+        visitor: &mut DecodeVisitor<R>,
+        config: Self::Config,
+    ) -> Result<Self, DecodeError>
+    where
+        R: BitRead,
+        Self: Sized,
+    {
+        let bytes = <Vec<u8> as EncodeableCustom>::decode_with_config(visitor, config.bytes)?;
+        String::from_utf8(bytes).map_err(DecodeError::InvalidUtf8)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::StringModel;
+    use crate::{DecodeError, EncodeableCustom};
+
+    #[test]
+    fn max_length_round_trips() {
+        let model = StringModel::new(100).unwrap();
+        assert_eq!(model.max_length(), 100);
+    }
+
+    #[test]
+    fn round_trips_ascii_and_multibyte() {
+        for s in [
+            "",
+            "hello",
+            "héllo wörld",
+            "😀 emoji",
+            "the quick brown fox",
+        ] {
+            let config = StringModel::new(64).unwrap();
+            let bytes = s.to_string().encode_bytes_with_config(config);
+            let decoded = String::decode_bytes_with_config(&bytes, config).unwrap();
+            assert_eq!(decoded, s);
+        }
+    }
+
+    #[test]
+    fn empty_and_max_length_round_trip() {
+        let config = StringModel::new(5).unwrap();
+
+        let empty = String::new();
+        let bytes = empty.encode_bytes_with_config(config);
+        assert_eq!(
+            String::decode_bytes_with_config(&bytes, config).unwrap(),
+            empty
+        );
+
+        let max = "abcde".to_string();
+        let bytes = max.encode_bytes_with_config(config);
+        assert_eq!(
+            String::decode_bytes_with_config(&bytes, config).unwrap(),
+            max
+        );
+    }
+
+    #[test]
+    fn encoding_over_max_length_is_rejected() {
+        let config = StringModel::new(2).unwrap();
+        let too_long = "abc".to_string();
+        let mut writer = bitstream_io::BitWriter::endian(Vec::new(), bitstream_io::BigEndian);
+        let mut encoder = crate::EncodeVisitor::new(crate::PRECISION, &mut writer);
+        let err = too_long
+            .encode_with_config(&mut encoder, config)
+            .unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn invalid_utf8_bytes_are_rejected_not_panicked() {
+        // Encode a raw `Vec<u8>` containing an invalid UTF-8 sequence (a lone
+        // continuation byte) using the same byte model `StringModel` uses
+        // internally, then decode it as a `String` and confirm it errors
+        // cleanly.
+        let config = StringModel::new(4).unwrap();
+        let invalid_bytes: Vec<u8> = vec![0xff, 0xfe];
+        let bytes = invalid_bytes.encode_bytes_with_config(crate::SeqModel {
+            max_len: u32::try_from(config.max_length()).unwrap(),
+            elem: crate::IntModel::<u8>::default(),
+        });
+
+        let err = String::decode_bytes_with_config(&bytes, config).unwrap_err();
+        assert!(matches!(err, DecodeError::InvalidUtf8(_)));
+    }
+
+    #[test]
+    fn rejects_max_length_over_u32() {
+        let err = StringModel::new(usize::MAX).unwrap_err();
+        assert!(matches!(err, crate::ModelError::DenominatorTooLarge { .. }));
+    }
+}

--- a/tests/adversarial.rs
+++ b/tests/adversarial.rs
@@ -108,7 +108,7 @@ fn truncated_valid_encodings_never_panic() {
         vehicle_class: Some(VehicleClass::Ship),
         battery_ok: Some(false),
     };
-    let encoded = report.encode_bytes();
+    let encoded = report.encode_bytes().unwrap();
 
     for len in 0..=encoded.len() {
         assert_no_panic::<Report>(&encoded[..len]);
@@ -116,14 +116,14 @@ fn truncated_valid_encodings_never_panic() {
 
     // Also exercise the simple leaf/​sum types.
     for value in [true, false] {
-        let bytes = value.encode_bytes();
+        let bytes = value.encode_bytes().unwrap();
         for len in 0..=bytes.len() {
             assert_no_panic::<bool>(&bytes[..len]);
         }
     }
 
     for value in [Some(true), Some(false), None] {
-        let bytes = value.encode_bytes();
+        let bytes = value.encode_bytes().unwrap();
         for len in 0..=bytes.len() {
             assert_no_panic::<Option<bool>>(&bytes[..len]);
         }
@@ -136,7 +136,7 @@ fn truncated_valid_encodings_never_panic() {
         flags: vec![true, false, true, true],
         label: "hello".to_string(),
     };
-    let bytes = with_sequences.encode_bytes();
+    let bytes = with_sequences.encode_bytes().unwrap();
     for len in 0..=bytes.len() {
         assert_no_panic::<WithSequences>(&bytes[..len]);
     }
@@ -154,9 +154,11 @@ fn corrupt_and_truncated_sequences_never_panic_or_oom() {
     let string_config = minnow::StringModel::new(12).unwrap();
 
     let valid_vec: Vec<bool> = vec![true, false, true];
-    let valid_vec_bytes = valid_vec.encode_bytes_with_config(seq_config);
+    let valid_vec_bytes = valid_vec.encode_bytes_with_config(seq_config).unwrap();
     let valid_string = "hello!".to_string();
-    let valid_string_bytes = valid_string.encode_bytes_with_config(string_config);
+    let valid_string_bytes = valid_string
+        .encode_bytes_with_config(string_config)
+        .unwrap();
 
     let mut rng = Rng::new(0xc0ff_ee00);
     for _ in 0..5_000 {
@@ -200,7 +202,7 @@ fn truncations_are_rejected() {
         vehicle_class: Some(VehicleClass::Ship),
         battery_ok: Some(false),
     };
-    let encoded = report.encode_bytes();
+    let encoded = report.encode_bytes().unwrap();
 
     assert!(
         Report::decode_bytes(&encoded).is_ok(),
@@ -233,7 +235,7 @@ fn valid_round_trip_still_works() {
         vehicle_class: Some(VehicleClass::Auv),
         battery_ok: None,
     };
-    let encoded = report.encode_bytes();
+    let encoded = report.encode_bytes().unwrap();
     let decoded = Report::decode_bytes(&encoded).unwrap();
     assert_eq!(report, decoded);
 }

--- a/tests/adversarial.rs
+++ b/tests/adversarial.rs
@@ -5,7 +5,7 @@
 //! and truncated byte strings through `decode_bytes` for a few representative
 //! types and assert only that the process does not panic.
 
-use minnow::Encodeable;
+use minnow::{Encodeable, EncodeableCustom};
 
 #[derive(Debug, Encodeable, PartialEq)]
 pub enum VehicleClass {
@@ -20,6 +20,19 @@ pub struct Report {
     pub x: f64,
     pub vehicle_class: Option<VehicleClass>,
     pub battery_ok: Option<bool>,
+}
+
+/// A fixture exercising the variable-length models: a bounded `Vec` (issue
+/// #5) and a bounded `String` (issue #3), both of which decode a length
+/// prefix from untrusted input before looping — exactly the code path that
+/// must reject a corrupt/oversized decoded length rather than trying to
+/// allocate or read past `max_len`/`max_length`.
+#[derive(Debug, Encodeable, PartialEq)]
+pub struct WithSequences {
+    #[encode(seq(max_len = 6))]
+    pub flags: Vec<bool>,
+    #[encode(string(max_length = 12))]
+    pub label: String,
 }
 
 /// A tiny deterministic PRNG (`xorshift64*`) so the test is reproducible
@@ -68,6 +81,22 @@ fn random_bytes_never_panic() {
         assert_no_panic::<Option<bool>>(&buf);
         assert_no_panic::<VehicleClass>(&buf);
         assert_no_panic::<Report>(&buf);
+        assert_no_panic::<WithSequences>(&buf);
+
+        // `Vec`/`String` have no `Default` config (there is no sensible
+        // universal `max_len`/`max_length`), so they aren't `Encodeable` and
+        // must be exercised through `decode_bytes_with_config` directly.
+        let _ = <Vec<bool> as minnow::EncodeableCustom>::decode_bytes_with_config(
+            &buf,
+            minnow::SeqModel {
+                max_len: 6,
+                elem: (),
+            },
+        );
+        let _ = <String as minnow::EncodeableCustom>::decode_bytes_with_config(
+            &buf,
+            minnow::StringModel::new(12).unwrap(),
+        );
     }
 }
 
@@ -98,6 +127,66 @@ fn truncated_valid_encodings_never_panic() {
         for len in 0..=bytes.len() {
             assert_no_panic::<Option<bool>>(&bytes[..len]);
         }
+    }
+
+    // And a fixture with variable-length (`Vec`/`String`) fields: truncating
+    // mid-way through the length prefix or the element/byte payload must
+    // still never panic.
+    let with_sequences = WithSequences {
+        flags: vec![true, false, true, true],
+        label: "hello".to_string(),
+    };
+    let bytes = with_sequences.encode_bytes();
+    for len in 0..=bytes.len() {
+        assert_no_panic::<WithSequences>(&bytes[..len]);
+    }
+}
+
+#[test]
+fn corrupt_and_truncated_sequences_never_panic_or_oom() {
+    // Every byte slice — random garbage or a truncation of a real encoding —
+    // fed through a `Vec`/`String` decode must terminate in `Ok`/`Err`, never
+    // panic and never attempt to allocate/read beyond `max_len`/`max_length`.
+    let seq_config = minnow::SeqModel {
+        max_len: 6_u32,
+        elem: (),
+    };
+    let string_config = minnow::StringModel::new(12).unwrap();
+
+    let valid_vec: Vec<bool> = vec![true, false, true];
+    let valid_vec_bytes = valid_vec.encode_bytes_with_config(seq_config);
+    let valid_string = "hello!".to_string();
+    let valid_string_bytes = valid_string.encode_bytes_with_config(string_config);
+
+    let mut rng = Rng::new(0xc0ff_ee00);
+    for _ in 0..5_000 {
+        let len = (rng.next_u64() % 16) as usize;
+        let mut buf = vec![0u8; len];
+        rng.fill(&mut buf);
+
+        if let Ok(decoded) =
+            <Vec<bool> as minnow::EncodeableCustom>::decode_bytes_with_config(&buf, seq_config)
+        {
+            assert!(decoded.len() <= seq_config.max_len as usize);
+        }
+        if let Ok(decoded) =
+            <String as minnow::EncodeableCustom>::decode_bytes_with_config(&buf, string_config)
+        {
+            assert!(decoded.len() <= string_config.max_length());
+        }
+    }
+
+    for len in 0..=valid_vec_bytes.len() {
+        let _ = <Vec<bool> as minnow::EncodeableCustom>::decode_bytes_with_config(
+            &valid_vec_bytes[..len],
+            seq_config,
+        );
+    }
+    for len in 0..=valid_string_bytes.len() {
+        let _ = <String as minnow::EncodeableCustom>::decode_bytes_with_config(
+            &valid_string_bytes[..len],
+            string_config,
+        );
     }
 }
 

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -12,7 +12,7 @@ fn round_trip() {
         three_vec: [1.0, 2.0, 3.0],
     };
 
-    let compressed = input.encode_bytes();
+    let compressed = input.encode_bytes().unwrap();
 
     let output = MyStruct::decode_bytes(&compressed).unwrap();
 

--- a/tests/custom_config.rs
+++ b/tests/custom_config.rs
@@ -41,14 +41,15 @@ impl EncodeableCustom for Bounded {
         &self,
         visitor: &mut EncodeVisitor<W>,
         config: Self::Config,
-    ) -> std::io::Result<()>
+    ) -> Result<(), minnow::EncodeError>
     where
         W: bitstream_io::BitWrite,
     {
         let model = minnow::WeightedModel::new(vec![1_u128; config.denominator() as usize]);
         #[allow(clippy::cast_sign_loss)]
         let symbol = (self.0 - config.min) as u32;
-        visitor.encode_one(model, &symbol)
+        visitor.encode_one(model, &symbol)?;
+        Ok(())
     }
 
     fn decode_with_config<R>(
@@ -74,7 +75,7 @@ pub struct WithCustomModel {
 #[test]
 fn custom_model_round_trips() {
     let input = WithCustomModel { level: Bounded(-3) };
-    let bytes = input.encode_bytes();
+    let bytes = input.encode_bytes().unwrap();
     let output = WithCustomModel::decode_bytes(&bytes).unwrap();
     assert_eq!(input, output);
 }
@@ -107,13 +108,13 @@ fn config_expr_matches_float_sugar() {
     let expr = ViaConfigExpr { x: 42.5 };
 
     // Same underlying model, so the wire format is identical.
-    assert_eq!(sugar.encode_bytes(), expr.encode_bytes());
+    assert_eq!(sugar.encode_bytes().unwrap(), expr.encode_bytes().unwrap());
     assert_eq!(
         ViaSugar::size_report().total_bytes(),
         ViaConfigExpr::size_report().total_bytes()
     );
 
-    let bytes = expr.encode_bytes();
+    let bytes = expr.encode_bytes().unwrap();
     let decoded = ViaConfigExpr::decode_bytes(&bytes).unwrap();
     assert_eq!(decoded, expr);
 }

--- a/tests/generic_struct.rs
+++ b/tests/generic_struct.rs
@@ -23,7 +23,7 @@ pub enum Either<A, B> {
 #[test]
 fn single_type_param_round_trips() {
     for value in [Wrapper { inner: true }, Wrapper { inner: false }] {
-        let bytes = value.encode_bytes();
+        let bytes = value.encode_bytes().unwrap();
         let decoded = Wrapper::<bool>::decode_bytes(&bytes).unwrap();
         assert_eq!(decoded, value);
     }
@@ -35,7 +35,7 @@ fn two_type_params_round_trip() {
         first: true,
         second: false,
     };
-    let bytes = value.encode_bytes();
+    let bytes = value.encode_bytes().unwrap();
     let decoded = Pair::<bool, bool>::decode_bytes(&bytes).unwrap();
     assert_eq!(decoded, value);
 }
@@ -43,7 +43,7 @@ fn two_type_params_round_trip() {
 #[test]
 fn generic_enum_round_trips() {
     for value in [Either::<bool, bool>::Left(true), Either::Right(false)] {
-        let bytes = value.encode_bytes();
+        let bytes = value.encode_bytes().unwrap();
         let decoded = Either::<bool, bool>::decode_bytes(&bytes).unwrap();
         assert_eq!(decoded, value);
     }

--- a/tests/int_model.rs
+++ b/tests/int_model.rs
@@ -28,7 +28,7 @@ fn round_trips_at_extremes() {
                     raw,
                     counter,
                 };
-                let bytes = value.encode_bytes();
+                let bytes = value.encode_bytes().unwrap();
                 let decoded = Reading::decode_bytes(&bytes).unwrap();
                 assert_eq!(decoded, value);
             }
@@ -40,7 +40,7 @@ fn round_trips_at_extremes() {
 fn negative_only_range_round_trips() {
     let config = IntModel::new(-1000_i32..=-1).unwrap();
     for value in [-1000, -500, -1] {
-        let bytes = value.encode_bytes_with_config(config);
+        let bytes = value.encode_bytes_with_config(config).unwrap();
         let decoded = i32::decode_bytes_with_config(&bytes, config).unwrap();
         assert_eq!(decoded, value);
     }
@@ -53,7 +53,7 @@ fn single_value_range_costs_zero_bits() {
     let config = IntModel::new(42_i32..=42).unwrap();
     assert_eq!(<i32 as EncodeableCustom>::weight(&config).get(), 1);
     assert_eq!(<i32 as EncodeableCustom>::worst_case_bits(&config), 0.0);
-    let bytes = 42_i32.encode_bytes_with_config(config);
+    let bytes = 42_i32.encode_bytes_with_config(config).unwrap();
     assert_eq!(i32::decode_bytes_with_config(&bytes, config).unwrap(), 42);
 }
 
@@ -61,7 +61,7 @@ fn single_value_range_costs_zero_bits() {
 fn i64_and_u64_extremes_round_trip() {
     let signed = IntModel::new(i64::MIN..=i64::MIN + 1_000_000).unwrap();
     for value in [i64::MIN, i64::MIN + 500_000, i64::MIN + 1_000_000] {
-        let bytes = value.encode_bytes_with_config(signed);
+        let bytes = value.encode_bytes_with_config(signed).unwrap();
         assert_eq!(
             i64::decode_bytes_with_config(&bytes, signed).unwrap(),
             value
@@ -70,7 +70,7 @@ fn i64_and_u64_extremes_round_trip() {
 
     let unsigned = IntModel::new(u64::MAX - 1_000_000..=u64::MAX).unwrap();
     for value in [u64::MAX - 1_000_000, u64::MAX - 500_000, u64::MAX] {
-        let bytes = value.encode_bytes_with_config(unsigned);
+        let bytes = value.encode_bytes_with_config(unsigned).unwrap();
         assert_eq!(
             u64::decode_bytes_with_config(&bytes, unsigned).unwrap(),
             value
@@ -92,7 +92,7 @@ fn size_law_holds() {
                     raw,
                     counter,
                 };
-                let bytes = value.encode_bytes();
+                let bytes = value.encode_bytes().unwrap();
                 assert!(bytes.len() <= upper);
                 lengths.push(bytes.len());
             }
@@ -115,4 +115,36 @@ fn worst_case_bits_matches_formula() {
         (bits - expected).abs() < 1e-9,
         "expected {expected}, got {bits}"
     );
+}
+
+/// Encode-domain semantics through the derive: out-of-range values error by
+/// default and clamp only under the explicit `clamping` flag.
+#[test]
+fn out_of_range_errors_by_default_and_clamps_on_opt_in() {
+    #[derive(Debug, Encodeable, PartialEq, Eq)]
+    struct Strict {
+        #[encode(int(min = 0, max = 10))]
+        value: u8,
+    }
+
+    #[derive(Debug, Encodeable, PartialEq, Eq)]
+    struct Clamped {
+        #[encode(int(min = 0, max = 10, clamping))]
+        value: u8,
+    }
+
+    assert!(matches!(
+        Strict { value: 200 }.encode_bytes(),
+        Err(minnow::EncodeError::OutOfRange { .. })
+    ));
+
+    let encoded = Clamped { value: 200 }.encode_bytes().unwrap();
+    assert_eq!(
+        Clamped::decode_bytes(&encoded).unwrap(),
+        Clamped { value: 10 }
+    );
+
+    // In-range values are untouched in either mode.
+    let encoded = Strict { value: 7 }.encode_bytes().unwrap();
+    assert_eq!(Strict::decode_bytes(&encoded).unwrap(), Strict { value: 7 });
 }

--- a/tests/int_model.rs
+++ b/tests/int_model.rs
@@ -1,0 +1,118 @@
+//! Round-trip and size-law tests for bounded integers (`IntModel`, issue #3's
+//! numeric sibling), both hand-configured and via the `#[encode(int(...))]`
+//! derive sugar.
+
+use minnow::{Encodeable, EncodeableCustom, IntModel};
+
+#[derive(Debug, Encodeable, PartialEq, Clone, Copy)]
+pub struct Reading {
+    // A small signed range, well within a single byte.
+    #[encode(int(min = -10, max = 10))]
+    pub delta: i32,
+    // `u8`'s `Default` config spans its full native range.
+    pub raw: u8,
+    // `u64` has no `Default`, so it always needs an explicit range.
+    #[encode(int(min = 0, max = 1_000_000))]
+    pub counter: u64,
+}
+
+// --- Round-trips at the extremes --------------------------------------------
+
+#[test]
+fn round_trips_at_extremes() {
+    for delta in [-10, -1, 0, 1, 10] {
+        for raw in [u8::MIN, 128, u8::MAX] {
+            for counter in [0, 500_000, 1_000_000] {
+                let value = Reading {
+                    delta,
+                    raw,
+                    counter,
+                };
+                let bytes = value.encode_bytes();
+                let decoded = Reading::decode_bytes(&bytes).unwrap();
+                assert_eq!(decoded, value);
+            }
+        }
+    }
+}
+
+#[test]
+fn negative_only_range_round_trips() {
+    let config = IntModel::new(-1000_i32..=-1).unwrap();
+    for value in [-1000, -500, -1] {
+        let bytes = value.encode_bytes_with_config(config);
+        let decoded = i32::decode_bytes_with_config(&bytes, config).unwrap();
+        assert_eq!(decoded, value);
+    }
+}
+
+#[test]
+fn single_value_range_costs_zero_bits() {
+    // A range with min == max has exactly one encodable value: weight 1,
+    // zero payload bits (matching a unit struct).
+    let config = IntModel::new(42_i32..=42).unwrap();
+    assert_eq!(<i32 as EncodeableCustom>::weight(&config).get(), 1);
+    assert_eq!(<i32 as EncodeableCustom>::worst_case_bits(&config), 0.0);
+    let bytes = 42_i32.encode_bytes_with_config(config);
+    assert_eq!(i32::decode_bytes_with_config(&bytes, config).unwrap(), 42);
+}
+
+#[test]
+fn i64_and_u64_extremes_round_trip() {
+    let signed = IntModel::new(i64::MIN..=i64::MIN + 1_000_000).unwrap();
+    for value in [i64::MIN, i64::MIN + 500_000, i64::MIN + 1_000_000] {
+        let bytes = value.encode_bytes_with_config(signed);
+        assert_eq!(
+            i64::decode_bytes_with_config(&bytes, signed).unwrap(),
+            value
+        );
+    }
+
+    let unsigned = IntModel::new(u64::MAX - 1_000_000..=u64::MAX).unwrap();
+    for value in [u64::MAX - 1_000_000, u64::MAX - 500_000, u64::MAX] {
+        let bytes = value.encode_bytes_with_config(unsigned);
+        assert_eq!(
+            u64::decode_bytes_with_config(&bytes, unsigned).unwrap(),
+            value
+        );
+    }
+}
+
+// --- Size law ----------------------------------------------------------------
+
+#[test]
+fn size_law_holds() {
+    let upper = Reading::size_report().total_bytes();
+    let mut lengths = Vec::new();
+    for delta in [-10, 0, 10] {
+        for raw in [0, 255] {
+            for counter in [0, 1_000_000] {
+                let value = Reading {
+                    delta,
+                    raw,
+                    counter,
+                };
+                let bytes = value.encode_bytes();
+                assert!(bytes.len() <= upper);
+                lengths.push(bytes.len());
+            }
+        }
+    }
+    // Uniform weighting: every value should encode to (near enough) the same
+    // length.
+    let min = *lengths.iter().min().unwrap();
+    let max = *lengths.iter().max().unwrap();
+    assert!(max - min <= 1, "min={min} max={max}");
+}
+
+#[test]
+fn worst_case_bits_matches_formula() {
+    // delta: 21 values -> log2(21); raw: 256 values -> log2(256) = 8;
+    // counter: 1_000_001 values -> log2(1_000_001).
+    let expected = 21_f64.log2() + 256_f64.log2() + 1_000_001_f64.log2();
+    let bits = <Reading as Encodeable>::worst_case_bits();
+    assert!(
+        (bits - expected).abs() < 1e-9,
+        "expected {expected}, got {bits}"
+    );
+}

--- a/tests/manual_weight.rs
+++ b/tests/manual_weight.rs
@@ -33,8 +33,8 @@ fn repeated_heavy_variant_encodes_smaller() {
     let commons = [Biased::Common; 64];
     let rares = [Biased::Rare; 64];
 
-    let common_len = commons.encode_bytes().len();
-    let rare_len = rares.encode_bytes().len();
+    let common_len = commons.encode_bytes().unwrap().len();
+    let rare_len = rares.encode_bytes().unwrap().len();
 
     assert!(
         common_len < rare_len,
@@ -43,8 +43,8 @@ fn repeated_heavy_variant_encodes_smaller() {
 
     // Both still round-trip, even though their lengths differ wildly: the decode
     // length check must not reject the (very short) all-Common encoding.
-    let commons_bytes = commons.encode_bytes();
-    let rares_bytes = rares.encode_bytes();
+    let commons_bytes = commons.encode_bytes().unwrap();
+    let rares_bytes = rares.encode_bytes().unwrap();
     assert_eq!(
         <[Biased; 64]>::decode_bytes(&commons_bytes).unwrap(),
         commons

--- a/tests/nested_vec.rs
+++ b/tests/nested_vec.rs
@@ -56,7 +56,7 @@ fn round_trips_at_length_extremes() {
         let fleet = Fleet {
             reports: (0..len).map(sample_report).collect(),
         };
-        let bytes = fleet.encode_bytes();
+        let bytes = fleet.encode_bytes().unwrap();
         let decoded = Fleet::decode_bytes(&bytes).unwrap();
         assert_eq!(decoded, fleet);
     }
@@ -83,7 +83,7 @@ fn size_matches_length_prefix_plus_reports() {
     let full_fleet = Fleet {
         reports: (0..10).map(sample_report).collect(),
     };
-    let bytes = full_fleet.encode_bytes();
+    let bytes = full_fleet.encode_bytes().unwrap();
     assert!(bytes.len() <= upper);
 }
 

--- a/tests/nested_vec.rs
+++ b/tests/nested_vec.rs
@@ -1,0 +1,103 @@
+//! `Vec<NavigationReport>`-style nesting: a derived struct (whose own
+//! `Config` is always `()`, so it needs no `elem` expression in the `seq(...)`
+//! sugar) collected into a bounded `Vec`. This is the shape Phase 5's DCCL
+//! comparison example builds on (a fleet of reports in one message).
+
+use minnow::Encodeable;
+
+#[derive(Debug, Encodeable, PartialEq, Clone, Copy)]
+pub enum VehicleClass {
+    Auv,
+    Usv,
+    Ship,
+}
+
+#[derive(Debug, Encodeable, PartialEq, Clone, Copy)]
+pub struct NavigationReport {
+    #[encode(float(min = -10_000.0, max = 10_000.0, precision = 1))]
+    pub x: f64,
+    #[encode(float(min = -10_000.0, max = 10_000.0, precision = 1))]
+    pub y: f64,
+    #[encode(float(min = -5_000.0, max = 0.0, precision = 0))]
+    pub z: f64,
+    pub vehicle_class: Option<VehicleClass>,
+    pub battery_ok: Option<bool>,
+}
+
+/// A bounded fleet of navigation reports: `NavigationReport::Config == ()`,
+/// which implements `Default`, so `elem` is omitted entirely — the same
+/// sugar as an unannotated leaf field.
+#[derive(Debug, Encodeable, PartialEq, Clone)]
+pub struct Fleet {
+    #[encode(seq(max_len = 10))]
+    pub reports: Vec<NavigationReport>,
+}
+
+fn sample_report(seed: u32) -> NavigationReport {
+    #[allow(clippy::cast_precision_loss)]
+    let seed = f64::from(seed);
+    NavigationReport {
+        x: (seed * 137.0) % 10_000.0 - 5_000.0,
+        y: (seed * 91.0) % 10_000.0 - 5_000.0,
+        z: -((seed * 53.0) % 5_000.0),
+        vehicle_class: match seed as u32 % 4 {
+            0 => None,
+            1 => Some(VehicleClass::Auv),
+            2 => Some(VehicleClass::Usv),
+            _ => Some(VehicleClass::Ship),
+        },
+        battery_ok: Some(seed as u32 % 2 == 0),
+    }
+}
+
+#[test]
+fn round_trips_at_length_extremes() {
+    for len in [0, 1, 10] {
+        let fleet = Fleet {
+            reports: (0..len).map(sample_report).collect(),
+        };
+        let bytes = fleet.encode_bytes();
+        let decoded = Fleet::decode_bytes(&bytes).unwrap();
+        assert_eq!(decoded, fleet);
+    }
+}
+
+#[test]
+fn size_matches_length_prefix_plus_reports() {
+    // Each report's worst-case size: `NavigationReport`'s own report total
+    // (17.6096*2 + 12.2882 + 2.0 + 1.585, see tests/size_law.rs), plus the
+    // uniform length prefix over 0..=10 (log2(11) bits), plus coder
+    // termination — matching `SeqModel`'s documented
+    // `worst_case_bits = log2(L+1) + L * worst_case_bits(elem)` formula.
+    let report_bits = <NavigationReport as Encodeable>::worst_case_bits();
+    let length_bits = 11_f64.log2();
+    let expected_worst = length_bits + 10.0 * report_bits;
+
+    let worst = <Fleet as Encodeable>::worst_case_bits();
+    assert!(
+        (worst - expected_worst).abs() < 1e-6,
+        "expected {expected_worst}, got {worst}"
+    );
+
+    let upper = Fleet::size_report().total_bytes();
+    let full_fleet = Fleet {
+        reports: (0..10).map(sample_report).collect(),
+    };
+    let bytes = full_fleet.encode_bytes();
+    assert!(bytes.len() <= upper);
+}
+
+#[test]
+fn beats_dccl_per_report_bit_budget() {
+    // DCCL3's default codec costs 18+18+13+2+2 = 53 bits per report
+    // (see the crate-level docs / Phase 5's DCCL comparison). Minnow's
+    // per-field float quantisation plus weighted `Option` discriminants
+    // already beats that per-report; this is the nested-`Vec` analogue of
+    // that comparison, checked directly against `NavigationReport`'s own
+    // measured worst-case bits.
+    let report_bits = <NavigationReport as Encodeable>::worst_case_bits();
+    assert!(
+        report_bits < 53.0,
+        "expected < 53 bits/report, got {report_bits}"
+    );
+}

--- a/tests/nested_vec.rs
+++ b/tests/nested_vec.rs
@@ -46,7 +46,7 @@ fn sample_report(seed: u32) -> NavigationReport {
             2 => Some(VehicleClass::Usv),
             _ => Some(VehicleClass::Ship),
         },
-        battery_ok: Some(seed as u32 % 2 == 0),
+        battery_ok: Some((seed as u32).is_multiple_of(2)),
     }
 }
 

--- a/tests/seq.rs
+++ b/tests/seq.rs
@@ -1,0 +1,144 @@
+//! Round-trip and size-law tests for `Vec<T>` (issue #5), both hand-configured
+//! (`SeqModel`) and via the `#[encode(seq(...))]` derive sugar.
+
+use minnow::{Encodeable, EncodeableCustom, FloatModel, SeqModel};
+
+#[derive(Debug, Encodeable, PartialEq, Clone, Copy)]
+pub enum Flag {
+    Red,
+    Green,
+    Blue,
+}
+
+#[derive(Debug, Encodeable, PartialEq, Clone)]
+pub struct Samples {
+    #[encode(seq(max_len = 5, elem = minnow::FloatModel::new(0.0..=10.0, 1).unwrap()))]
+    pub readings: Vec<f64>,
+    #[encode(seq(max_len = 5))]
+    pub flags: Vec<Flag>,
+}
+
+fn as_f64(i: usize) -> f64 {
+    f64::from(u32::try_from(i).unwrap())
+}
+
+// --- Round-trips at lengths {0, 1, max} -------------------------------------
+
+#[test]
+fn vec_f64_round_trips_at_length_extremes() {
+    let elem = FloatModel::new(0.0..=10.0, 1).unwrap();
+    for len in [0, 1, 5] {
+        let config = SeqModel {
+            max_len: 5,
+            elem: elem.clone(),
+        };
+        let value: Vec<f64> = (0..len).map(as_f64).collect();
+        let bytes = value.encode_bytes_with_config(config.clone());
+        let decoded = <Vec<f64>>::decode_bytes_with_config(&bytes, config).unwrap();
+        assert_eq!(decoded, value);
+    }
+}
+
+#[test]
+fn vec_enum_round_trips_at_length_extremes() {
+    let config = SeqModel {
+        max_len: 4,
+        elem: (),
+    };
+    let all = [Flag::Red, Flag::Green, Flag::Blue, Flag::Red];
+    for len in [0, 1, 4] {
+        let value: Vec<Flag> = all[..len].to_vec();
+        let bytes = value.encode_bytes_with_config(config);
+        let decoded = <Vec<Flag>>::decode_bytes_with_config(&bytes, config).unwrap();
+        assert_eq!(decoded, value);
+    }
+}
+
+#[test]
+fn derive_seq_sugar_round_trips() {
+    for len in [0, 1, 5] {
+        let value = Samples {
+            readings: (0..len).map(as_f64).collect(),
+            flags: vec![Flag::Blue; len],
+        };
+        let bytes = value.encode_bytes();
+        let decoded = Samples::decode_bytes(&bytes).unwrap();
+        assert_eq!(decoded, value);
+    }
+}
+
+// --- Size law: the tight per-length formula ---------------------------------
+//
+// For a variable-length sequence the size law is per-*value*, not a single
+// figure: a sequence of length `l` costs `log2(max_len + 1) + l * elem_bits`
+// payload bits, plus `TERMINATION_BITS` (2.0) of coder overhead, rounded up
+// to whole bytes.
+
+#[test]
+fn per_length_size_law_matches_formula() {
+    // For a *uniform* leaf, every value costs the same ideal (`f64`) number
+    // of bits, but the real arithmetic coder's actual output is an integer
+    // number of bits whose relationship to that ideal figure includes
+    // renormalisation/flush rounding (`TERMINATION_BITS` is an *upper* bound
+    // on termination cost, "at most two bits" — see `crate::TERMINATION_BITS`
+    // docs, not always exactly two). So the achieved byte length is pinned to
+    // within one byte of `ceil((length_bits + l * elem_bits +
+    // TERMINATION_BITS) / 8)` — the same one-byte tolerance
+    // `tests/size_law.rs` uses for fixed-size schemas — rather than always
+    // equal to it; and it must never exceed that figure, which is a genuine
+    // upper bound (`SizeReport::total_bytes`'s contract).
+    let elem = FloatModel::new(0.0..=10.0, 1).unwrap();
+    let elem_bits = <f64 as EncodeableCustom>::worst_case_bits(&elem);
+    let max_len = 5_u32;
+
+    for len in 0..=max_len {
+        let config = SeqModel {
+            max_len,
+            elem: elem.clone(),
+        };
+        let value: Vec<f64> = (0..len).map(|i| as_f64(i as usize)).collect();
+        let bytes = value.encode_bytes_with_config(config);
+
+        let expected_bits = (f64::from(max_len) + 1.0).log2()
+            + f64::from(len) * elem_bits
+            + minnow::TERMINATION_BITS;
+        let expected_bytes = (expected_bits / 8.0).ceil() as usize;
+
+        assert!(
+            bytes.len() <= expected_bytes && bytes.len() + 1 >= expected_bytes,
+            "length {len}: expected {expected_bytes} bytes (±1), got {}",
+            bytes.len()
+        );
+    }
+}
+
+#[test]
+fn best_and_worst_case_bits_match_formula() {
+    let elem = FloatModel::new(0.0..=10.0, 1).unwrap();
+    let elem_bits = <f64 as EncodeableCustom>::worst_case_bits(&elem);
+    let max_len = 5_u32;
+    let config = SeqModel { max_len, elem };
+
+    let length_bits = (f64::from(max_len) + 1.0).log2();
+    assert!((<Vec<f64> as EncodeableCustom>::best_case_bits(&config) - length_bits).abs() < 1e-9);
+    let expected_worst = length_bits + f64::from(max_len) * elem_bits;
+    assert!(
+        (<Vec<f64> as EncodeableCustom>::worst_case_bits(&config) - expected_worst).abs() < 1e-9
+    );
+}
+
+// --- Weight formula ----------------------------------------------------------
+
+#[test]
+fn weight_matches_geometric_sum_formula() {
+    // elem weight 3 (Flag has 3 variants), max_len 3:
+    // 1 + 3 + 9 + 27 = 40.
+    let config = SeqModel {
+        max_len: 3,
+        elem: (),
+    };
+    assert_eq!(
+        <Vec<Flag> as EncodeableCustom>::weight(&config).get(),
+        1 + 3 + 9 + 27
+    );
+}

--- a/tests/seq.rs
+++ b/tests/seq.rs
@@ -33,7 +33,7 @@ fn vec_f64_round_trips_at_length_extremes() {
             elem: elem.clone(),
         };
         let value: Vec<f64> = (0..len).map(as_f64).collect();
-        let bytes = value.encode_bytes_with_config(config.clone());
+        let bytes = value.encode_bytes_with_config(config.clone()).unwrap();
         let decoded = <Vec<f64>>::decode_bytes_with_config(&bytes, config).unwrap();
         assert_eq!(decoded, value);
     }
@@ -48,7 +48,7 @@ fn vec_enum_round_trips_at_length_extremes() {
     let all = [Flag::Red, Flag::Green, Flag::Blue, Flag::Red];
     for len in [0, 1, 4] {
         let value: Vec<Flag> = all[..len].to_vec();
-        let bytes = value.encode_bytes_with_config(config);
+        let bytes = value.encode_bytes_with_config(config).unwrap();
         let decoded = <Vec<Flag>>::decode_bytes_with_config(&bytes, config).unwrap();
         assert_eq!(decoded, value);
     }
@@ -61,7 +61,7 @@ fn derive_seq_sugar_round_trips() {
             readings: (0..len).map(as_f64).collect(),
             flags: vec![Flag::Blue; len],
         };
-        let bytes = value.encode_bytes();
+        let bytes = value.encode_bytes().unwrap();
         let decoded = Samples::decode_bytes(&bytes).unwrap();
         assert_eq!(decoded, value);
     }
@@ -97,7 +97,7 @@ fn per_length_size_law_matches_formula() {
             elem: elem.clone(),
         };
         let value: Vec<f64> = (0..len).map(|i| as_f64(i as usize)).collect();
-        let bytes = value.encode_bytes_with_config(config);
+        let bytes = value.encode_bytes_with_config(config).unwrap();
 
         let expected_bits = (f64::from(max_len) + 1.0).log2()
             + f64::from(len) * elem_bits

--- a/tests/size_law.rs
+++ b/tests/size_law.rs
@@ -104,7 +104,7 @@ where
     let mut max = 0usize;
 
     for value in values {
-        let bytes = value.encode_bytes();
+        let bytes = value.encode_bytes().unwrap();
         let len = bytes.len();
         assert!(
             len <= upper,
@@ -112,7 +112,7 @@ where
         );
         let decoded = T::decode_bytes(&bytes).expect("a valid encoding must decode");
         assert_eq!(
-            decoded.encode_bytes(),
+            decoded.encode_bytes().unwrap(),
             bytes,
             "re-encoding the decoded value must be stable",
         );
@@ -211,7 +211,7 @@ fn option_vehicle_class_is_exactly_two_bits() {
     ];
     let mut lengths = Vec::new();
     for value in values {
-        let bytes = value.encode_bytes();
+        let bytes = value.encode_bytes().unwrap();
         assert!(bytes.len() <= 1, "should fit in a single byte");
         assert_eq!(Option::<VehicleClass>::decode_bytes(&bytes).unwrap(), value);
         lengths.push(bytes.len());

--- a/tests/string.rs
+++ b/tests/string.rs
@@ -14,7 +14,7 @@ fn round_trips_empty_and_max_and_multibyte() {
     let config = StringModel::new(16).unwrap();
 
     // Empty.
-    let bytes = String::new().encode_bytes_with_config(config);
+    let bytes = String::new().encode_bytes_with_config(config).unwrap();
     assert_eq!(
         String::decode_bytes_with_config(&bytes, config).unwrap(),
         ""
@@ -23,7 +23,7 @@ fn round_trips_empty_and_max_and_multibyte() {
     // Exactly max_length bytes (ASCII, so 16 bytes == 16 chars).
     let max = "0123456789abcdef".to_string();
     assert_eq!(max.len(), 16);
-    let bytes = max.clone().encode_bytes_with_config(config);
+    let bytes = max.clone().encode_bytes_with_config(config).unwrap();
     assert_eq!(
         String::decode_bytes_with_config(&bytes, config).unwrap(),
         max
@@ -32,7 +32,7 @@ fn round_trips_empty_and_max_and_multibyte() {
     // Multibyte UTF-8 (emoji, accented characters), well under the byte
     // budget.
     for s in ["héllo", "日本語", "🦀🎉", "café"] {
-        let bytes = s.to_string().encode_bytes_with_config(config);
+        let bytes = s.to_string().encode_bytes_with_config(config).unwrap();
         assert_eq!(String::decode_bytes_with_config(&bytes, config).unwrap(), s);
     }
 }
@@ -43,7 +43,7 @@ fn derive_string_sugar_round_trips() {
         let value = Message {
             text: text.to_string(),
         };
-        let bytes = value.encode_bytes();
+        let bytes = value.encode_bytes().unwrap();
         let decoded = Message::decode_bytes(&bytes).unwrap();
         assert_eq!(decoded, value);
     }
@@ -67,7 +67,7 @@ fn encoding_beyond_max_length_is_rejected_not_panicked() {
         .text
         .encode_with_config(&mut encoder, config)
         .unwrap_err();
-    assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+    assert!(matches!(err, minnow::EncodeError::TooLong { .. }));
 }
 
 fn minnow_derive_config() -> StringModel {
@@ -83,10 +83,12 @@ fn corrupt_bytes_never_panic_and_invalid_utf8_is_reported() {
     for len in 0..8 {
         for fill in [0x00_u8, 0xff_u8] {
             let raw_bytes: Vec<u8> = vec![fill; len];
-            let encoded = raw_bytes.encode_bytes_with_config(minnow::SeqModel {
-                max_len: 8,
-                elem: minnow::IntModel::<u8>::default(),
-            });
+            let encoded = raw_bytes
+                .encode_bytes_with_config(minnow::SeqModel {
+                    max_len: 8,
+                    elem: minnow::IntModel::<u8>::default(),
+                })
+                .unwrap();
             let result = String::decode_bytes_with_config(&encoded, config);
             // Either it's a valid (if degenerate) UTF-8 string, or it's
             // reported as invalid UTF-8 -- either way, no panic, and any

--- a/tests/string.rs
+++ b/tests/string.rs
@@ -1,0 +1,102 @@
+//! Round-trip tests for `String` (issue #3), both hand-configured
+//! (`StringModel`) and via the `#[encode(string(...))]` derive sugar.
+
+use minnow::{DecodeError, Encodeable, EncodeableCustom, StringModel};
+
+#[derive(Debug, Encodeable, PartialEq, Clone)]
+pub struct Message {
+    #[encode(string(max_length = 32))]
+    pub text: String,
+}
+
+#[test]
+fn round_trips_empty_and_max_and_multibyte() {
+    let config = StringModel::new(16).unwrap();
+
+    // Empty.
+    let bytes = String::new().encode_bytes_with_config(config);
+    assert_eq!(
+        String::decode_bytes_with_config(&bytes, config).unwrap(),
+        ""
+    );
+
+    // Exactly max_length bytes (ASCII, so 16 bytes == 16 chars).
+    let max = "0123456789abcdef".to_string();
+    assert_eq!(max.len(), 16);
+    let bytes = max.clone().encode_bytes_with_config(config);
+    assert_eq!(
+        String::decode_bytes_with_config(&bytes, config).unwrap(),
+        max
+    );
+
+    // Multibyte UTF-8 (emoji, accented characters), well under the byte
+    // budget.
+    for s in ["héllo", "日本語", "🦀🎉", "café"] {
+        let bytes = s.to_string().encode_bytes_with_config(config);
+        assert_eq!(String::decode_bytes_with_config(&bytes, config).unwrap(), s);
+    }
+}
+
+#[test]
+fn derive_string_sugar_round_trips() {
+    for text in ["", "hello, world!", "日本語のテスト"] {
+        let value = Message {
+            text: text.to_string(),
+        };
+        let bytes = value.encode_bytes();
+        let decoded = Message::decode_bytes(&bytes).unwrap();
+        assert_eq!(decoded, value);
+    }
+}
+
+#[test]
+fn encoding_beyond_max_length_is_rejected_not_panicked() {
+    let value = Message {
+        // Each 'x' is a 3-byte character (well beyond the 32-byte budget in
+        // total), exercising the byte-length (not char-count) bound.
+        text: "€".repeat(20),
+    };
+    // `encode_bytes` panics on I/O failure (infallible for `Vec<u8>` in
+    // general), but exceeding `max_length` is a configuration error the
+    // fallible `encode_with_config` path must surface cleanly rather than
+    // panic.
+    let mut writer = bitstream_io::BitWriter::endian(Vec::new(), bitstream_io::BigEndian);
+    let mut encoder = minnow::EncodeVisitor::new(minnow::PRECISION, &mut writer);
+    let config = minnow_derive_config();
+    let err = value
+        .text
+        .encode_with_config(&mut encoder, config)
+        .unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+}
+
+fn minnow_derive_config() -> StringModel {
+    StringModel::new(32).unwrap()
+}
+
+#[test]
+fn corrupt_bytes_never_panic_and_invalid_utf8_is_reported() {
+    // Feed a hand-built, well-formed-length-but-corrupt byte sequence through
+    // `String`'s decode path and confirm it either decodes or reports
+    // `InvalidUtf8`/other `DecodeError` — never panics.
+    let config = StringModel::new(8).unwrap();
+    for len in 0..8 {
+        for fill in [0x00_u8, 0xff_u8] {
+            let raw_bytes: Vec<u8> = vec![fill; len];
+            let encoded = raw_bytes.encode_bytes_with_config(minnow::SeqModel {
+                max_len: 8,
+                elem: minnow::IntModel::<u8>::default(),
+            });
+            let result = String::decode_bytes_with_config(&encoded, config);
+            // Either it's a valid (if degenerate) UTF-8 string, or it's
+            // reported as invalid UTF-8 -- either way, no panic, and any
+            // error is a `DecodeError`.
+            if let Err(err) = result {
+                assert!(matches!(
+                    err,
+                    DecodeError::InvalidUtf8(_) | DecodeError::Length { .. }
+                ));
+            }
+        }
+    }
+}

--- a/tests/struct_variant_enum.rs
+++ b/tests/struct_variant_enum.rs
@@ -68,7 +68,7 @@ fn round_trip_every_variant_kind() {
         },
     ];
     for value in values {
-        let bytes = value.encode_bytes();
+        let bytes = value.encode_bytes().unwrap();
         let decoded = Shape::decode_bytes(&bytes).expect("valid encoding must decode");
         assert_eq!(decoded, value);
     }
@@ -81,14 +81,18 @@ fn size_law_holds_across_variant_kinds() {
 
     for _ in 0..5_000 {
         let value = rng.shape();
-        let bytes = value.encode_bytes();
+        let bytes = value.encode_bytes().unwrap();
         assert!(
             bytes.len() <= upper,
             "{value:?} encoded to {} bytes, exceeding size_report().total_bytes() = {upper}",
             bytes.len(),
         );
         let decoded = Shape::decode_bytes(&bytes).expect("a valid encoding must decode");
-        assert_eq!(decoded.encode_bytes(), bytes, "re-encoding must be stable");
+        assert_eq!(
+            decoded.encode_bytes().unwrap(),
+            bytes,
+            "re-encoding must be stable"
+        );
     }
 }
 

--- a/tests/tuple_enum.rs
+++ b/tests/tuple_enum.rs
@@ -18,7 +18,7 @@ pub enum MyNestedEnum {
 fn round_trip() {
     let input = MyNestedEnum::B(MyEnum::A(5.0));
 
-    let compressed = input.encode_bytes();
+    let compressed = input.encode_bytes().unwrap();
 
     let output = MyNestedEnum::decode_bytes(&compressed).unwrap();
 

--- a/tests/tuple_struct.rs
+++ b/tests/tuple_struct.rs
@@ -13,7 +13,7 @@ pub struct MyNestedStruct(MyStruct);
 fn round_trip() {
     let input = MyNestedStruct(MyStruct(5.0, 10.0));
 
-    let compressed = input.encode_bytes();
+    let compressed = input.encode_bytes().unwrap();
 
     let output = MyNestedStruct::decode_bytes(&compressed).unwrap();
 

--- a/tests/unit_enum.rs
+++ b/tests/unit_enum.rs
@@ -11,7 +11,7 @@ pub enum MyEnum {
 fn round_trip() {
     let input = MyEnum::B;
 
-    let compressed = input.encode_bytes();
+    let compressed = input.encode_bytes().unwrap();
 
     let output = MyEnum::decode_bytes(&compressed).unwrap();
 


### PR DESCRIPTION
**Stacked on #69** (← #68 ← #67); retarget as the stack merges.

Adds the missing leaf and container models, closing #3 and #5.

## What's included
- **`IntModel<T>`**: bounded integers over `min..=max` for `u8..u64`/`i8..i64` (one `i128`-backed implementation), weight `max − min + 1`, with `#[encode(int(min = a, max = b))]` sugar. Full-range `Default` configs where the range fits the coder's denominator cap; `u64`/`i64` require explicit bounds (documented). Macro-time validation mirrors the runtime constructor exactly, with boundary tests at `MAX_DENOMINATOR`.
- **`SeqModel`** for `Vec<T>` (#5): uniform length prefix over `0..=max_len`, then the elements — deliberately *not* cardinality-weighted so short vectors stay cheap (trade-off documented with the math: weight `Σₖ W(elem)ᵏ`, worst case `log₂(L+1) + L·w(elem)`, best case `log₂(L+1)`). Encoding an over-length vector is an error; decoded lengths are validated against `max_len` before any allocation.
- **`StringModel`** (#3): UTF-8 bytes as a byte-sequence model (`max_length` in bytes) — the type the derive's `string(...)` form has referenced since 2022 now exists and compiles end-to-end. Invalid UTF-8 on decode surfaces as `DecodeError::InvalidUtf8`, never a panic.
- `#[encode(seq(max_len = N, elem = <expr>))]` sugar, `()` impl, and `ModelError` unified across all fallible model constructors (a small deviation from the plan sketch: `StringModel::new` is fallible like its siblings, keeping one invariant-enforcement story).
- **Tests** (137 workspace-wide): int extremes/negative ranges, Vec/String at lengths {0, 1, max} with per-length size assertions, multibyte UTF-8, adversarial fuzz/truncation for the new types, and a `Vec<NavigationReport>` fixture asserting the per-report cost stays under DCCL's 53-bit budget (feeds the upcoming comparison example).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BRpeiPNoowJaMhAk2WYUMp

---
_Generated by [Claude Code](https://claude.ai/code/session_01BRpeiPNoowJaMhAk2WYUMp)_