### PR TITLE
Derive completeness, new models, fallible encoding, and docs (#3, #4, #5, #8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ let input = NavigationReport {
     battery_ok: Some(true),
 };
 
-let compressed = input.encode_bytes();
+let compressed = input.encode_bytes().unwrap();
 let output = NavigationReport::decode_bytes(&compressed).unwrap();
 
 assert_eq!(input, output);

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ Minnow is a library for serialising objects into extremely compact binary repres
 
 Minnow is a derive macro and convenience layer over the [Arithmetic-Coding](https://github.com/danieleades/arithmetic-coding) library.
 
+Minnow was originally conceived as a library for creating compact messages for underwater acoustic communications. It is heavily inspired by [Dynamic Compact Control Language (DCCL)](https://libdccl.org/3.0/), and — as shown below — reliably beats DCCL's own worst-case size for the schemas DCCL was designed around, because Minnow spends *fractional* bits per field instead of rounding every field up to a whole number of bits.
+
+## Licensing
+
+This project is publicly available under the GNU General Public License v3.0. It may optionally be distributed under the permissive MIT license by commercial arrangement.
+
+## Quick start
+
 ```rust
 use minnow::Encodeable;
 
@@ -40,11 +48,262 @@ let output = NavigationReport::decode_bytes(&compressed).unwrap();
 assert_eq!(input, output);
 ```
 
-Minnow builds on **stable** Rust. Decoding operates on untrusted input, so
-`decode_bytes` returns a `Result<_, minnow::DecodeError>` and never panics.
+Minnow builds on **stable** Rust — no nightly toolchain or unstable features required. Decoding operates on untrusted input, so `decode_bytes` returns a `Result<Self, minnow::DecodeError>` rather than panicking: a truncated, corrupt, or malformed byte string is always reported as an error, never undefined behaviour or a crash.
 
-Minnow was originally conceived as a library for creating compact messages for underwater acoustic communications. It is heavily inspired by [Dynamic Compact Control Language (DCCL)](https://libdccl.org/3.0/)
+`NavigationReport` above encodes to **7 bytes** — see [How Minnow compresses](#how-minnow-compresses) for exactly why.
 
-## Licensing
+## How Minnow compresses
 
-This project is publicly available under the GNU General Public License v3.0. It may optionally be distributed under the permissive MIT license by commercial arrangement.
+Minnow's compression rests on one idea: every encodeable type `T` has a
+**weight** `W(T)` — the number of distinct values it can encode — and the
+number of bits needed to encode *any* value of `T` is `log₂ W(T)`, no more.
+Getting every schema down to that bound, exactly, for every value, is what
+the rest of this section explains.
+
+### Weights are a semiring
+
+| Type | Weight |
+|---|---|
+| leaf model (`bool`, quantised `f64`, bounded integer, …) | the model's denominator `N` |
+| product (struct, tuple, `[T; N]`) | `∏ W(fieldᵢ)` |
+| sum (enum, `Option<T>`) | `Σ W(variantᵥ)` |
+| bounded sequence (`Vec<T>`, `String`, max length `L`) | `Σ_{k=0}^{L} W(T)^k` |
+
+Structs multiply their fields' weights together (a product type — more
+fields means more distinguishable combinations). Enums add their variants'
+weights (a sum type — a value is *one* variant *or* another). This is a
+commutative semiring homomorphism into the natural numbers, and the size
+report (`size_report()`) is its image under `w ↦ log₂ w`, which turns
+products into sums of bit counts and turns the enum sum rule into a
+per-variant cost — see [`Weight`](https://docs.rs/minnow/latest/minnow/struct.Weight.html)
+and [`SizeReport`](https://docs.rs/minnow/latest/minnow/struct.SizeReport.html).
+
+### Weighted discriminants: the minimax-optimal encoding
+
+A naive enum encoding assigns every variant the same discriminant cost
+(`log₂(variant count)` bits) regardless of how much each variant's payload
+actually varies. Minnow instead encodes the discriminant with a **weighted**
+model: the arithmetic coder's interval is split into `k` sub-intervals whose
+*widths* are proportional to each variant's payload weight, rather than all
+being equal. Concretely, for a total `S = Σᵥ W(v)`, variant `v` gets an
+interval of width `W(v)`, so:
+
+```text
+cost(discriminant of v) = log2(S / W(v))
+cost(payload of v)      = log2(W(v))
+total                   = log2(S)          — the same, for every v
+```
+
+That total is identical for every variant, and it equals `log₂ W(T)` for the
+whole sum type. This is not a heuristic: `log₂ W(T)` is the
+information-theoretic minimum worst-case length for a code over `W(T)`
+distinguishable values (no code can beat it, by a basic counting argument),
+and uniform leaves plus weighted discriminants achieve that bound with
+equality for *every* value — not just on average. Encoding terminates with
+at most `TERMINATION_BITS = 2.0` bits of flush overhead beyond that, from
+finalising the arithmetic coder's internal state, so the true worst case is
+`log₂ W(T) + 2` bits. This all falls out automatically from the derive macro:
+no annotation is needed to get weighted discriminants on an enum or
+`Option<T>`.
+
+**Worked example** — `Option<VehicleClass>`, where `VehicleClass` has three
+unit variants (`W(VehicleClass) = 3`):
+
+* **Naive, uniform discriminant** (a 50/50 `None`-vs-`Some` bit, then the
+  payload if present): `1 + log₂(3) ≈ 2.58` bits worst case.
+* **Weighted discriminant** (what the derive actually emits: `{None: 1,
+  Some: 3}`, total `S = 4`): every value — `None`, `Some(Auv)`,
+  `Some(Usv)`, `Some(Ship)` — costs exactly `log₂(4) = 2.0` bits.
+
+See `examples/weighted_enum.rs` for this worked example as runnable code
+(it asserts the 2.0-bit figure), and `tests/size_law.rs` for the same
+assertion as a regression test.
+
+Applied to the quick-start example: `NavigationReport`'s two position floats
+(200,001 distinguishable values each, `min = -10,000.0, max = 10,000.0,
+precision = 1`) cost `log₂(200,001) ≈ 17.61` bits each; its depth float
+(5,001 values, `min = -5,000.0, max = 0.0, precision = 0`) costs `log₂(5,001)
+≈ 12.29` bits; the weighted `Option<VehicleClass>` costs exactly `2.00` bits;
+the weighted `Option<bool>` costs exactly `log₂(3) ≈ 1.58` bits. Summed:
+**51.09 bits**, which — with the 2-bit termination overhead folded in and
+rounded up to a whole byte — is **7 bytes**. DCCL3's default codec, which
+whole-bit-packs each field (`ceil(log₂ N)` bits, discarding the fractional
+remainder), costs `18 + 18 + 13 + 2 + 2 = 53` bits for the identical schema.
+Minnow's fractional accounting recovers essentially all of that 1.91-bit
+slack. `examples/dccl_comparison.rs` extends this to a repeated,
+bounded `Vec<NavigationReport>` and measures actual encoded bytes against
+DCCL's formula across several lengths.
+
+### Manual weights: optimising for a known prior
+
+`#[encode(weight = N)]` on an enum variant overrides its automatic
+(payload-cardinality) discriminant weight. This subsumes the automatic case
+rather than replacing it: with weights set proportional to *prior
+probability × payload weight*, the induced code minimises **expected**
+length (the classical Shannon-optimal code for a known distribution); with
+the default weights (payload weight only), it minimises **worst-case**
+length. One mechanism, two provable optimality modes, chosen by what you put
+in the attribute.
+
+For example, biasing a two-variant enum so one variant is a thousand times
+more likely than the other:
+
+```rust
+use minnow::{Encodeable, EncodeableCustom};
+
+#[derive(Debug, Encodeable)]
+enum Reading {
+    #[encode(weight = 1000)]
+    Common,
+    Rare,
+}
+
+// Cardinality is unchanged (still 2 distinct values) — only the *coding*
+// cost shifts.
+assert_eq!(<Reading as EncodeableCustom>::weight(&()).get(), 2);
+
+// `Common` costs log2(1001/1000) ≈ 0.0014 bits; `Rare` costs log2(1001) ≈
+// 9.97 bits. An array of all-`Common` values now encodes far smaller than
+// an array of all-`Rare` values, even though both are the "same type".
+```
+
+See `tests/manual_weight.rs` for this example exercised end-to-end
+(including the round trip and the size comparison on repeated values).
+
+### Sequences: a deliberate exception
+
+For `Vec<T>` and `String`, Minnow does **not** use a cardinality-weighted
+length the way it does for enum discriminants. A weighted length would make
+every value of `Vec<T>` cost exactly `log₂ W(Vec<T>)` bits — matching the
+enum scheme's minimax optimality — but nearly all of that cardinality lives
+in the longest possible sequence (`k = L`), so the **empty** sequence would
+cost almost as much as the **longest** one. That defeats the entire purpose
+of a variable-length field: short values should be cheap.
+
+Instead, Minnow prefixes a sequence with a **uniform** length symbol over
+`0..=L` (`log₂(L + 1)` bits), then encodes that many elements at their own
+per-element cost:
+
+```text
+worst_case_bits(Vec<T>) = log2(L + 1) + L * worst_case_bits(T)
+best_case_bits(Vec<T>)  = log2(L + 1)                            (the empty sequence)
+```
+
+The trade-off, quantified precisely: relative to the minimax-optimal
+`log₂ W(Vec<T>)` bound, the uniform length prefix costs `log₂(L + 1) −
+log₂(A / (A − 1))` extra worst-case bits (where `A = W(T)`) — for
+`A = 200,001` (one of `NavigationReport`'s float fields) and `L = 10` that's
+about `3.459 − 0.000007 ≈ 3.459` bits of redundancy. In exchange, a
+short sequence of length `k` costs `log₂(L + 1) + k · log₂ A` — not
+`log₂ W(Vec<T>)` regardless of `k` — which is the property that actually
+matters for variable-length data. A cardinality-weighted length model is a
+possible opt-in follow-up; it is not implemented today.
+
+`String` is modelled as exactly this sequence scheme over raw UTF-8 bytes
+(`SeqModel<IntModel<u8>>` under the hood, `max_length` in **bytes**, each
+byte uniform over all 256 values); an alphabet-restricted model (e.g.
+printable ASCII, à la DCCL) would shrink the per-byte cost below 8 bits but
+is not implemented here.
+
+## Size reports
+
+`Encodeable::size_report()` returns a [`SizeReport`] tree describing the
+worst-case encoded size of a schema, broken down per field/variant — this
+answers "how big can this message get?" without having to encode a worst-case
+value by hand. Running `examples/navigation_report.rs`:
+
+```text
+size report:
+total: 51.09 bits (7 bytes)
+  x: 17.61 bits
+  y: 17.61 bits
+  z: 12.29 bits
+  vehicle_class: 2.00 bits
+  battery_ok: 1.58 bits
+```
+
+`total_bytes()` (`7` above) is a genuine upper bound on `encode_bytes().len()`
+for any value of the type: it is `ceil((total_bits + TERMINATION_BITS) / 8)`,
+where `TERMINATION_BITS = 2.0` accounts for the arithmetic coder's flush
+overhead. Under Minnow's default (automatic) weighting every value of a fixed
+schema encodes to the *same* length (up to that termination rounding), so the
+size report is not just an upper bound — it is, in practice, the size.
+
+## Supported types and attribute forms
+
+A field (struct field, or enum-variant field/payload) carries at most one
+`#[encode(...)]` attribute naming its runtime configuration. No attribute
+means `Config::default()`.
+
+| Rust type | `#[encode(...)]` form | Weight | Notes |
+|---|---|---|---|
+| `bool` | *(none)* | `2` | uniform coin flip |
+| `f64` | `float(min = a, max = b, precision = p)` | `round((b − a) · 10^p) + 1` | lossy quantisation to `p` decimal digits (`p` may be negative); `Default` spans ±1,000,000 at precision 0 |
+| `u8`, `u16`, `u32`, `i8`, `i16`, `i32` | `int(min = a, max = b)` | `b − a + 1` | `Default` spans the type's full native range |
+| `u64`, `i64` | `int(min = a, max = b)` | `b − a + 1` | no `Default`: the full native range (`2^64`) exceeds the coder's precision bound |
+| `String` | `string(max_length = n)` | bounded byte-sequence weight | UTF-8 bytes, uniform over 256 per byte, `n` in bytes |
+| `Vec<T>` | `seq(max_len = n)` or `seq(max_len = n, elem = <expr>)` | `Σ_{k=0}^{n} W(T)^k` | uniform length prefix (see "sequences" above); `elem` may be omitted when `T::Config: Default` |
+| `Option<T>` | *(automatic)* | `1 + W(T)` | weighted discriminant — no annotation needed |
+| enum (unit / tuple / struct variants) | per-field/payload attributes, plus optional `weight = N` per variant | `Σ W(variant)` | weighted discriminant by default; `weight` overrides it (see "manual weights" above) |
+| struct / tuple struct | per-field attributes | `∏ W(field)` | product rule |
+| `[T; N]` | the element's own attribute, applied once | `W(T)^N` | fixed-size array |
+| `()` / unit struct / unit variant | *(none)* | `1` | zero bits on the wire |
+| any type implementing `EncodeableCustom` | `config = <expr>` | user-defined | the escape hatch every other form is sugar for — an arbitrary Rust expression evaluated as the runtime config |
+
+## Encode-domain semantics: errors, not silent coercion
+
+A value outside its model's configured range **fails to encode** with a typed
+`EncodeError::OutOfRange` rather than being silently coerced. The distinction
+Minnow draws is between two kinds of loss:
+
+- **In-range quantisation** (450.03 → 450.0 at `precision = 1`) always
+  happens and is not an error: its loss is bounded by half a quantisation
+  step, which the schema explicitly declares.
+- **Out-of-range coercion** (12 000 clamped to a declared maximum of 10 000)
+  has *unbounded* loss and delivers plausible-but-wrong data to the receiver,
+  so it is an error unless a field explicitly opts in.
+
+Fields backed by naturally saturating sources (sensor channels) can opt into
+clamping — `FloatModel::new(…)?.clamping()`, `IntModel::new(…)?.clamping()`,
+or the `clamping` flag in the derive attributes:
+
+```rust,ignore
+#[encode(float(min = -10_000.0, max = 10_000.0, precision = 1, clamping))]
+pub x: f64,
+```
+
+NaN and infinite floats are an `EncodeError::NonFinite` in every mode (no
+nearest representable value exists), and a `Vec`/`String` longer than its
+`max_len` is an `EncodeError::TooLong` (truncation would drop elements, which
+is not a nearest-value projection — there is no clamping mode for sequences).
+
+## Integrity
+
+Minnow's arithmetic-coded output is **not self-validating**. An
+arithmetic-coded stream is not self-delimiting the way, say, a
+length-prefixed or tag-delimited format is: almost every byte string of a
+plausible length decodes to *some* value of the schema, valid or not.
+
+Two mitigations are built in, but neither is a full checksum:
+
+* **Length window.** Before decoding, `decode_bytes` validates the input's
+  length against the schema's `[best_case_bits, total_bytes]` window (see
+  [`DecodeError::Length`]). Under uniform (automatic) weighting that window
+  is at most one byte wide, so this reliably catches whole-byte truncation
+  or a message from the wrong schema — but it cannot detect corruption that
+  preserves the byte count.
+* **Symbol validation.** A decoded discriminant or length outside its
+  model's valid range is reported as [`DecodeError::InvalidSymbol`] rather
+  than causing undefined behaviour or an out-of-bounds access — but a
+  corrupt stream that happens to decode to *in-range* symbols throughout
+  will decode to `Ok` with a silently wrong value.
+
+Applications that need genuine end-to-end integrity — detecting bit flips,
+partial corruption, or tampering — should wrap Minnow's output in their own
+outer framing (e.g. a CRC or cryptographic checksum over `encode_bytes()`'s
+output), the same way DCCL relies on its own transport framing rather than
+building integrity checks into the codec itself.
+
+[`SizeReport`]: https://docs.rs/minnow/latest/minnow/struct.SizeReport.html
+[`DecodeError::Length`]: https://docs.rs/minnow/latest/minnow/enum.DecodeError.html#variant.Length
+[`DecodeError::InvalidSymbol`]: https://docs.rs/minnow/latest/minnow/enum.DecodeError.html#variant.InvalidSymbol

--- a/examples/dccl_comparison.rs
+++ b/examples/dccl_comparison.rs
@@ -1,0 +1,124 @@
+//! Compares Minnow's actual encoded size for a bounded `Vec<NavigationReport>`
+//! against DCCL3's documented worst-case size for the same schema.
+//!
+//! The `NavigationReport`/`VehicleClass` shape mirrors `tests/nested_vec.rs`
+//! (a fleet of reports bounded to `max_len = 16`).
+//!
+//! # The DCCL side: formula, not measurement
+//!
+//! The DCCL figures below are **computed from DCCL3's documented default
+//! codec rules**, not measured against a real `libdccl` build linked into
+//! this repository — there is no DCCL installation here to compare against.
+//! Per the default-codec docs (<https://libdccl.org/3.0/>), each field is
+//! packed into a *whole* number of bits, `ceil(log2(N))` for a field with `N`
+//! distinguishable values:
+//!
+//! * `x`, `y`: `ceil(log2(200_001)) = 18` bits each (range ±10,000 at 0.1
+//!   precision),
+//! * `z`: `ceil(log2(5_001)) = 13` bits (range \[-5,000, 0\] at 1.0 precision),
+//! * `vehicle_class` (`Option<VehicleClass>`, 4 values including `None`):
+//!   `ceil(log2(4)) = 2` bits,
+//! * `battery_ok` (`Option<bool>`, 3 values including `None`): `ceil(log2(3)) =
+//!   2` bits,
+//!
+//! for a fixed **53 bits/report** (`18+18+13+2+2`). A repeated field also
+//! costs a `ceil(log2(max_repeat + 1))`-bit count prefix, and DCCL messages
+//! carry a 1-byte message ID. The whole message is then byte-padded once
+//! (not once per field, not once per repeated element) — this is the
+//! "byte-packed" scheme that makes DCCL simple to implement but leaves
+//! sub-bit redundancy on the table, which is exactly what Minnow's
+//! fractional arithmetic coding recovers.
+//!
+//! # The Minnow side: measured, not estimated
+//!
+//! Minnow's byte counts below are the **actual `encode_bytes().len()`** of a
+//! real `Fleet` value for each `n` — not a formula. (Under Minnow's uniform
+//! weighting every value of a fixed schema encodes to the same length; see
+//! `tests/size_law.rs`.)
+
+use minnow::Encodeable;
+
+#[derive(Debug, Encodeable, PartialEq, Clone, Copy)]
+pub enum VehicleClass {
+    Auv,
+    Usv,
+    Ship,
+}
+
+#[derive(Debug, Encodeable, PartialEq, Clone, Copy)]
+pub struct NavigationReport {
+    #[encode(float(min = -10_000.0, max = 10_000.0, precision = 1))]
+    pub x: f64,
+    #[encode(float(min = -10_000.0, max = 10_000.0, precision = 1))]
+    pub y: f64,
+    #[encode(float(min = -5_000.0, max = 0.0, precision = 0))]
+    pub z: f64,
+    pub vehicle_class: Option<VehicleClass>,
+    pub battery_ok: Option<bool>,
+}
+
+/// A bounded fleet of navigation reports, `max_len = 16`.
+#[derive(Debug, Encodeable, PartialEq, Clone)]
+pub struct Fleet {
+    #[encode(seq(max_len = 16))]
+    pub reports: Vec<NavigationReport>,
+}
+
+const MAX_REPEAT: u32 = 16;
+
+/// DCCL3's documented worst-case bits per report: `18 + 18 + 13 + 2 + 2`
+/// (whole-bit `ceil(log2(N))` packing per field — see the module docs).
+const DCCL_BITS_PER_REPORT: u32 = 18 + 18 + 13 + 2 + 2;
+
+/// DCCL3's documented worst-case size, in bytes, for a message containing
+/// `n` repeated `NavigationReport`s: a 1-byte message ID, plus a
+/// `ceil(log2(max_repeat + 1))`-bit repetition count, plus `n` reports at
+/// [`DCCL_BITS_PER_REPORT`] bits each — all packed into whole bits and
+/// byte-padded exactly once at the end.
+fn dccl_bytes(n: u32) -> u32 {
+    let message_id_bits = 8;
+    let count_bits = (MAX_REPEAT + 1).ilog2() + 1; // ceil(log2(max_repeat + 1))
+    let total_bits = message_id_bits + count_bits + n * DCCL_BITS_PER_REPORT;
+    total_bits.div_ceil(8)
+}
+
+/// A small deterministic generator for sample reports, so the table doesn't
+/// depend on Minnow's compression happening to favour one particular value.
+fn sample_report(seed: u32) -> NavigationReport {
+    #[allow(clippy::cast_precision_loss)]
+    let seed_f = f64::from(seed);
+    NavigationReport {
+        x: (seed_f * 137.0) % 10_000.0 - 5_000.0,
+        y: (seed_f * 91.0) % 10_000.0 - 5_000.0,
+        z: -((seed_f * 53.0) % 5_000.0),
+        vehicle_class: match seed % 4 {
+            0 => None,
+            1 => Some(VehicleClass::Auv),
+            2 => Some(VehicleClass::Usv),
+            _ => Some(VehicleClass::Ship),
+        },
+        battery_ok: Some(seed.is_multiple_of(2)),
+    }
+}
+
+fn main() {
+    println!(
+        "{:>3}  {:>11}  {:>13}",
+        "n", "dccl (bytes)", "minnow (bytes)"
+    );
+    for n in [1_u32, 5, 10, 16] {
+        let fleet = Fleet {
+            reports: (0..n).map(sample_report).collect(),
+        };
+        let minnow_bytes = fleet.encode_bytes().unwrap().len();
+        let dccl = dccl_bytes(n);
+
+        println!("{n:>3}  {dccl:>11}  {minnow_bytes:>13}");
+
+        assert!(
+            (minnow_bytes as u32) <= dccl,
+            "minnow ({minnow_bytes} bytes) should never exceed DCCL's worst case ({dccl} bytes) \
+             at n={n}"
+        );
+    }
+}

--- a/examples/navigation_report.rs
+++ b/examples/navigation_report.rs
@@ -37,7 +37,7 @@ fn main() {
     // 53 bits. See <https://libdccl.org/3.0/>.
     println!("\nsize report:\n{}", NavigationReport::size_report());
 
-    let compressed = input.encode_bytes();
+    let compressed = input.encode_bytes().unwrap();
 
     println!("bytes: {:x?}, length: {}", compressed, compressed.len());
 

--- a/examples/struct_enum.rs
+++ b/examples/struct_enum.rs
@@ -17,7 +17,7 @@ fn y_model() -> FloatModel<f64> {
 }
 
 impl Encodeable for MyEnum {
-    fn encode<W>(&self, visitor: &mut minnow::EncodeVisitor<W>) -> std::io::Result<()>
+    fn encode<W>(&self, visitor: &mut minnow::EncodeVisitor<W>) -> Result<(), minnow::EncodeError>
     where
         W: bitstream_io::BitWrite,
     {
@@ -82,7 +82,7 @@ fn main() {
     for input in [MyEnum::A { x: -5.0, y: 15.0 }, MyEnum::B] {
         println!("input: {input:?}");
 
-        let compressed = input.encode_bytes();
+        let compressed = input.encode_bytes().unwrap();
         println!("bytes: {}", compressed.len());
 
         let output = MyEnum::decode_bytes(&compressed).expect("round-trip should succeed");

--- a/examples/struct_variants.rs
+++ b/examples/struct_variants.rs
@@ -1,0 +1,37 @@
+//! Struct-style and multi-field tuple enum variants (issue #4), fully
+//! derived — contrast with `examples/struct_enum.rs`, which deliberately
+//! hand-writes its `Encodeable` impl to show what the derive used to be
+//! unable to generate.
+
+use minnow::Encodeable;
+
+#[derive(Debug, Encodeable)]
+pub enum Shape {
+    Point,
+    Circle {
+        #[encode(float(min = 0.0, max = 1_000.0, precision = 1))]
+        radius: f64,
+    },
+    Rectangle(
+        #[encode(float(min = 0.0, max = 1_000.0, precision = 1))] f64,
+        #[encode(float(min = 0.0, max = 1_000.0, precision = 1))] f64,
+    ),
+}
+
+fn main() {
+    println!("size report:\n{}", Shape::size_report());
+
+    for input in [
+        Shape::Point,
+        Shape::Circle { radius: 12.5 },
+        Shape::Rectangle(3.0, 4.0),
+    ] {
+        println!("input: {input:?}");
+
+        let compressed = input.encode_bytes();
+        println!("bytes: {}", compressed.len());
+
+        let output = Shape::decode_bytes(&compressed).expect("round-trip should succeed");
+        println!("output: {output:?}");
+    }
+}

--- a/examples/struct_variants.rs
+++ b/examples/struct_variants.rs
@@ -28,7 +28,7 @@ fn main() {
     ] {
         println!("input: {input:?}");
 
-        let compressed = input.encode_bytes();
+        let compressed = input.encode_bytes().unwrap();
         println!("bytes: {}", compressed.len());
 
         let output = Shape::decode_bytes(&compressed).expect("round-trip should succeed");

--- a/examples/weighted_enum.rs
+++ b/examples/weighted_enum.rs
@@ -1,0 +1,57 @@
+//! Issue #9's optimisation, in miniature: a weighted enum discriminant makes
+//! every value of `Option<VehicleClass>` cost the *same*, minimal number of
+//! bits, rather than paying a fixed 1-bit tax for the `Option` regardless of
+//! how few values the payload has.
+//!
+//! `VehicleClass` has three variants (weight 3); wrapped in `Option` that's
+//! `{None: 1, Some: 3}`, total weight `W = 1 + 3 = 4`.
+//!
+//! * **Naive / uniform discriminant** (a plain 50/50 `None`-vs-`Some` bit, then
+//!   the payload if present): `1 + log2(3) ≈ 2.58` bits worst case — the
+//!   discriminant bit is "wasted" because `None` and `Some` aren't equally
+//!   likely outcomes of a 4-value type.
+//! * **Weighted discriminant** (interval widths proportional to `{1, 3}`, what
+//!   Minnow's derive does automatically — see the crate-level "How Minnow
+//!   compresses" docs): exactly `log2(4) = 2.0` bits, for *every* value, no
+//!   annotation required. This is the information-theoretic minimum for a
+//!   4-valued type.
+
+use minnow::Encodeable;
+
+#[derive(Debug, Encodeable, PartialEq, Clone, Copy)]
+pub enum VehicleClass {
+    Auv,
+    Usv,
+    Ship,
+}
+
+fn main() {
+    // `Option<VehicleClass>` is exactly the shape issue #9 asked for: no
+    // `#[encode(weight = ...)]` needed, the derive weights `None`/`Some`
+    // automatically by payload cardinality.
+    println!("size report:\n{}", <Option<VehicleClass>>::size_report());
+
+    let bits = <Option<VehicleClass>>::worst_case_bits();
+    let naive_bits = 1.0 + 3_f64.log2();
+    println!(
+        "\nweighted worst case: {bits:.2} bits (naive uniform discriminant would cost \
+         {naive_bits:.2} bits)"
+    );
+    assert!(
+        (bits - 2.0).abs() < 1e-9,
+        "Option<VehicleClass> should cost exactly 2.0 bits, got {bits}"
+    );
+
+    for input in [
+        None,
+        Some(VehicleClass::Auv),
+        Some(VehicleClass::Usv),
+        Some(VehicleClass::Ship),
+    ] {
+        let compressed = input.encode_bytes().unwrap();
+        let output =
+            <Option<VehicleClass>>::decode_bytes(&compressed).expect("round-trip should succeed");
+        assert_eq!(input, output);
+        println!("input: {input:?}, bytes: {}", compressed.len());
+    }
+}

--- a/minnow-derive/Cargo.toml
+++ b/minnow-derive/Cargo.toml
@@ -19,5 +19,8 @@ proc-macro2 = "1.0.37"
 quote = "1.0.17"
 
 [dev-dependencies]
+bitstream-io = "2"
+minnow = { path = ".." }
 proc-macro2 = "1.0.37"
 test-case = "3.0.0"
+trybuild = "1"

--- a/minnow-derive/Cargo.toml
+++ b/minnow-derive/Cargo.toml
@@ -19,7 +19,7 @@ proc-macro2 = "1.0.37"
 quote = "1.0.17"
 
 [dev-dependencies]
-bitstream-io = "2"
+bitstream-io = "4"
 minnow = { path = ".." }
 proc-macro2 = "1.0.37"
 test-case = "3.0.0"

--- a/minnow-derive/src/lib.rs
+++ b/minnow-derive/src/lib.rs
@@ -29,7 +29,41 @@ mod write;
 ///   `min`/`max`/`precision` are validated at macro-expansion time (mirroring
 ///   `FloatModel::new`), so an out-of-range or inverted bound is a compile
 ///   error, not a runtime panic.
-/// * `#[encode(string(max_length = ...))]` — sugar for a `StringModel`.
+///
+///   ```rust,ignore
+///   #[encode(float(min = -10_000.0, max = 10_000.0, precision = 1))]
+///   pub x: f64,
+///   ```
+///
+/// * `#[encode(int(min = ..., max = ...))]` — sugar for an [`IntModel`](https://docs.rs/minnow/latest/minnow/struct.IntModel.html);
+///   the target integer type is inferred from the field, and bounds are
+///   validated at macro-expansion time exactly like `float`.
+///
+///   ```rust,ignore
+///   #[encode(int(min = 0, max = 200))]
+///   pub age: u8,
+///   ```
+///
+/// * `#[encode(string(max_length = ...))]` — sugar for a [`StringModel`](https://docs.rs/minnow/latest/minnow/struct.StringModel.html)
+///   (`max_length` in bytes).
+///
+///   ```rust,ignore
+///   #[encode(string(max_length = 64))]
+///   pub name: String,
+///   ```
+///
+/// * `#[encode(seq(max_len = ..., elem = <expr>))]` — sugar for a [`SeqModel`](https://docs.rs/minnow/latest/minnow/struct.SeqModel.html)
+///   wrapping a bounded `Vec<T>`. `elem` is the per-element config expression
+///   and may be omitted when `T::Config: Default`.
+///
+///   ```rust,ignore
+///   #[encode(seq(max_len = 16))]
+///   pub flags: Vec<bool>,
+///
+///   #[encode(seq(max_len = 8, elem = float_model()))]
+///   pub samples: Vec<f64>,
+///   ```
+///
 /// * `#[encode(config = <expr>)]` — the general escape hatch every other form
 ///   is sugar for: an arbitrary Rust expression, evaluated at runtime and
 ///   passed as the field's config. Because the expression is arbitrary, it
@@ -37,6 +71,12 @@ mod write;
 ///   syntax, or a value of the wrong `Config` type) surfaces as an ordinary
 ///   compile error at its interpolation site inside the generated impl, rather
 ///   than a clean macro diagnostic pointing at the attribute.
+///
+///   ```rust,ignore
+///   #[encode(config = my_crate::custom_model())]
+///   pub reading: MyType,
+///   ```
+///
 /// * No attribute — the field's config is `Default::default()` (works for any
 ///   `Config: Default`, most commonly `Config = ()`).
 ///
@@ -48,8 +88,21 @@ mod write;
 /// # Enum discriminant weighting
 ///
 /// An enum variant may also carry `#[encode(weight = N)]`, overriding its
-/// automatic (payload-cardinality) discriminant weight — see the `minnow`
-/// crate documentation for the weighted-enum theory.
+/// automatic (payload-cardinality) discriminant weight:
+///
+/// ```rust,ignore
+/// #[derive(Encodeable)]
+/// enum Reading {
+///     #[encode(weight = 1000)]
+///     Common,
+///     Rare,
+/// }
+/// ```
+///
+/// See the `minnow` crate documentation ("How Minnow compresses" in the
+/// README) for the weighted-enum theory: this is the same mechanism behind
+/// automatic weighting, so it composes with both the worst-case-optimal
+/// default and a manually-supplied prior.
 ///
 /// # Generics
 ///

--- a/minnow-derive/src/lib.rs
+++ b/minnow-derive/src/lib.rs
@@ -12,6 +12,53 @@ mod parse;
 mod process;
 mod write;
 
+/// Derives [`EncodeableCustom`](https://docs.rs/minnow/latest/minnow/trait.EncodeableCustom.html)
+/// (and, through it, `Encodeable`) for a struct or enum.
+///
+/// Supports plain, tuple, and struct-style structs; and unit, tuple
+/// (single- or multi-field), and struct-style enum variants. A struct's
+/// fields, and an enum variant's payload fields, are encoded/decoded in
+/// declaration order.
+///
+/// # Field attributes
+///
+/// A field (struct or enum-variant) may carry one `#[encode(...)]` attribute
+/// naming its runtime config:
+///
+/// * `#[encode(float(min = ..., max = ..., precision = ...))]` — sugar for a [`FloatModel`](https://docs.rs/minnow/latest/minnow/struct.FloatModel.html);
+///   `min`/`max`/`precision` are validated at macro-expansion time (mirroring
+///   `FloatModel::new`), so an out-of-range or inverted bound is a compile
+///   error, not a runtime panic.
+/// * `#[encode(string(max_length = ...))]` — sugar for a `StringModel`.
+/// * `#[encode(config = <expr>)]` — the general escape hatch every other form
+///   is sugar for: an arbitrary Rust expression, evaluated at runtime and
+///   passed as the field's config. Because the expression is arbitrary, it
+///   **cannot** be validated at macro-expansion time — a bad expression (bad
+///   syntax, or a value of the wrong `Config` type) surfaces as an ordinary
+///   compile error at its interpolation site inside the generated impl, rather
+///   than a clean macro diagnostic pointing at the attribute.
+/// * No attribute — the field's config is `Default::default()` (works for any
+///   `Config: Default`, most commonly `Config = ()`).
+///
+/// For backward compatibility, a single-field tuple variant may instead carry
+/// its payload model directly on the variant (`#[encode(float(...))]
+/// Foo(f64)`); this is equivalent to putting the attribute on the sole field,
+/// and cannot be combined with a field-level attribute on the same field.
+///
+/// # Enum discriminant weighting
+///
+/// An enum variant may also carry `#[encode(weight = N)]`, overriding its
+/// automatic (payload-cardinality) discriminant weight — see the `minnow`
+/// crate documentation for the weighted-enum theory.
+///
+/// # Generics
+///
+/// A generic type parameter used directly as a field's type (`inner: T`)
+/// automatically gets an `EncodeableCustom` bound (plus a `Config: Default`
+/// bound, if that field has no explicit `#[encode(...)]` attribute) added to
+/// the generated impl's where-clause. A type parameter used only indirectly
+/// (e.g. inside `Option<T>`) needs its bounds spelled out by hand on the type
+/// declaration.
 #[proc_macro_derive(Encodeable, attributes(encode))]
 pub fn derive(input: TokenStream) -> TokenStream {
     let derive_input = parse_macro_input!(input as syn::DeriveInput);

--- a/minnow-derive/src/parse.rs
+++ b/minnow-derive/src/parse.rs
@@ -1,3 +1,14 @@
+//! Stage 1 of the derive pipeline (`parse` → `process` → `write`): turn the
+//! `syn::DeriveInput` for a `#[derive(Encodeable)]` struct or enum into a
+//! [`Receiver`] — a `syn`/`darling`-shaped view of the input with every
+//! `#[encode(...)]` attribute parsed into a [`Model`] (and, for enum
+//! variants, an optional manual `weight`) and validated against the coder's
+//! precision invariant.
+//!
+//! This stage owns attribute syntax and macro-expansion-time validation only;
+//! it does not decide *how* a field or variant gets encoded, which is
+//! [`crate::process`]'s job.
+
 use darling::{Error, FromDeriveInput, FromMeta, ast, export::syn};
 use syn::Attribute;
 

--- a/minnow-derive/src/parse.rs
+++ b/minnow-derive/src/parse.rs
@@ -48,6 +48,11 @@ macro_rules! impl_signed_number {
 
 impl_signed_number!(f64);
 impl_signed_number!(i8);
+// `i128` is wide enough to hold the full range of every integer type
+// `IntModel` supports (`u8..=u64`, `i8..=i64`), so `int(min = ..., max =
+// ...)` parses both bounds through this one signed representation regardless
+// of the field's actual integer type; see `Model::config_tokens`.
+impl_signed_number!(i128);
 
 #[derive(FromMeta)]
 pub enum Model {
@@ -55,9 +60,34 @@ pub enum Model {
         min: Number<f64>,
         max: Number<f64>,
         precision: Number<i8>,
+        /// `clamping` opts into coercing out-of-range values to the nearest
+        /// bound instead of an `EncodeError::OutOfRange`.
+        #[darling(default)]
+        clamping: bool,
+    },
+    /// `#[encode(int(min = a, max = b))]` — a bounded integer, uniform over
+    /// `a..=b`. Lowers to `minnow::IntModel::new(a..=b)`; the target integer
+    /// type is inferred from the field, not from this attribute (see
+    /// [`Model::config_tokens`]).
+    Int {
+        min: Number<i128>,
+        max: Number<i128>,
+        /// `clamping` opts into coercing out-of-range values to the nearest
+        /// bound instead of an `EncodeError::OutOfRange`.
+        #[darling(default)]
+        clamping: bool,
     },
     String {
         max_length: usize,
+    },
+    /// `#[encode(seq(max_len = N, elem = <expr>))]` — a bounded `Vec<T>`,
+    /// length-prefixed over `0..=N`. `elem` is the per-element config
+    /// expression; it may be omitted when `T::Config: Default`, in which case
+    /// it lowers to `Default::default()` like an unannotated field would.
+    Seq {
+        max_len: u32,
+        #[darling(default)]
+        elem: Option<syn::Expr>,
     },
     /// `#[encode(config = <expr>)]` — an arbitrary Rust expression evaluated
     /// as the field's runtime config. This is the escape hatch every other
@@ -88,12 +118,46 @@ impl Model {
                 min: Number(min),
                 max: Number(max),
                 precision: Number(precision),
-            }) => quote! {
-                minnow::FloatModel::new( #min ..= #max, #precision )
-                    .expect("model bounds validated at compile time")
-            },
+                clamping,
+            }) => {
+                let clamping = clamping.then(|| quote! { .clamping() });
+                quote! {
+                    minnow::FloatModel::new( #min ..= #max, #precision )
+                        .expect("model bounds validated at compile time")
+                        #clamping
+                }
+            }
+            Some(Self::Int {
+                min: Number(min),
+                max: Number(max),
+                clamping,
+            }) => {
+                let clamping = clamping.then(|| quote! { .clamping() });
+                // Emit unsuffixed integer literals so their type is inferred
+                // from context (the field's concrete integer type, via
+                // `IntModel<T>`'s `T`) rather than fixed to `i128`.
+                let min = proc_macro2::Literal::i128_unsuffixed(*min);
+                let max = proc_macro2::Literal::i128_unsuffixed(*max);
+                quote! {
+                    minnow::IntModel::new( #min ..= #max )
+                        .expect("model bounds validated at compile time")
+                        #clamping
+                }
+            }
             Some(Self::String { max_length }) => {
-                quote! { minnow::StringModel::new( #max_length ) }
+                quote! {
+                    minnow::StringModel::new( #max_length )
+                        .expect("model bounds validated at compile time")
+                }
+            }
+            Some(Self::Seq { max_len, elem }) => {
+                let elem = elem.as_ref().map_or_else(
+                    || quote! { ::core::default::Default::default() },
+                    |expr| quote! { #expr },
+                );
+                quote! {
+                    minnow::SeqModel { max_len: #max_len, elem: #elem }
+                }
             }
             Some(Self::Config(expr)) => quote! { #expr },
             // Fall back to `Default::default()` rather than a literal `()` so
@@ -108,44 +172,101 @@ impl Model {
     /// Validate a model's parameters at macro-expansion time so that invalid
     /// bounds become a clean compile error rather than a runtime panic.
     fn validate(&self) -> Result<(), String> {
-        if let Model::Float {
-            min: Number(min),
-            max: Number(max),
-            precision: Number(precision),
-        } = self
-        {
-            if !min.is_finite() || !max.is_finite() {
-                return Err("float model bounds must be finite (neither NaN nor infinite)".into());
+        match self {
+            Model::Float {
+                min: Number(min),
+                max: Number(max),
+                precision: Number(precision),
+                clamping: _,
+            } => {
+                if !min.is_finite() || !max.is_finite() {
+                    return Err(
+                        "float model bounds must be finite (neither NaN nor infinite)".into(),
+                    );
+                }
+                if min > max {
+                    return Err(format!(
+                        "float model lower bound ({min}) must not exceed the upper bound ({max})"
+                    ));
+                }
+                // This must mirror `FloatModel::new` exactly (same f64
+                // arithmetic, then the same *integer* comparison) so that
+                // anything accepted here is also accepted at runtime.
+                // Comparing in f64 instead would disagree near the boundary,
+                // where `steps + 1.0` rounds back to `MAX_DENOMINATOR`.
+                let multiplier = 10_f64.powi(i32::from(*precision));
+                let steps = ((max - min) * multiplier).round();
+                let steps = num_traits::ToPrimitive::to_u128(&steps).ok_or_else(|| {
+                    format!(
+                        "float model denominator exceeds the maximum ({MAX_DENOMINATOR}) \
+                         permitted at precision 64; narrow the range or reduce the precision"
+                    )
+                })?;
+                // `denominator = steps + 1`; reject before the `+ 1` can
+                // overflow or exceed the bound.
+                if steps >= MAX_DENOMINATOR {
+                    return Err(format!(
+                        "float model denominator ({}) exceeds the maximum ({MAX_DENOMINATOR}) \
+                         permitted at precision 64; narrow the range or reduce the precision",
+                        steps.saturating_add(1)
+                    ));
+                }
+                Ok(())
             }
-            if min > max {
-                return Err(format!(
-                    "float model lower bound ({min}) must not exceed the upper bound ({max})"
-                ));
+            Model::Int {
+                min: Number(min),
+                max: Number(max),
+                clamping: _,
+            } => {
+                if min > max {
+                    return Err(format!(
+                        "int model lower bound ({min}) must not exceed the upper bound ({max})"
+                    ));
+                }
+                // This must mirror `IntModel::new` exactly: an `i128`
+                // difference, then the same integer comparison against
+                // `MAX_DENOMINATOR`.
+                let width = max.checked_sub(*min).ok_or_else(|| {
+                    "int model range width overflows i128; narrow the range".to_string()
+                })?;
+                let width = u128::try_from(width).map_err(|_| {
+                    "int model range width overflows i128; narrow the range".to_string()
+                })?;
+                // `denominator = width + 1`; reject before the `+ 1` can
+                // overflow or exceed the bound.
+                if width >= MAX_DENOMINATOR {
+                    return Err(format!(
+                        "int model denominator ({}) exceeds the maximum ({MAX_DENOMINATOR}) \
+                         permitted at precision 64; narrow the range",
+                        width.saturating_add(1)
+                    ));
+                }
+                Ok(())
             }
-            // This must mirror `FloatModel::new` exactly (same f64 arithmetic,
-            // then the same *integer* comparison) so that anything accepted
-            // here is also accepted at runtime. Comparing in f64 instead would
-            // disagree near the boundary, where `steps + 1.0` rounds back to
-            // `MAX_DENOMINATOR`.
-            let multiplier = 10_f64.powi(i32::from(*precision));
-            let steps = ((max - min) * multiplier).round();
-            let steps = num_traits::ToPrimitive::to_u128(&steps).ok_or_else(|| {
-                format!(
-                    "float model denominator exceeds the maximum ({MAX_DENOMINATOR}) permitted at \
-                     precision 64; narrow the range or reduce the precision"
-                )
-            })?;
-            // `denominator = steps + 1`; reject before the `+ 1` can overflow
-            // or exceed the bound.
-            if steps >= MAX_DENOMINATOR {
-                return Err(format!(
-                    "float model denominator ({}) exceeds the maximum ({MAX_DENOMINATOR}) \
-                     permitted at precision 64; narrow the range or reduce the precision",
-                    steps.saturating_add(1)
-                ));
+            Model::String { max_length } => {
+                // Mirrors `StringModel::new`: the only way construction can
+                // fail is `max_length` not fitting in the `u32` that backs
+                // `SeqModel::max_len` — a `u32`-bounded length model's
+                // denominator (`max_length + 1 <= 2^32`) is always far below
+                // `MAX_DENOMINATOR` (`~2^62`), so that's the only check
+                // needed here.
+                if u32::try_from(*max_length).is_err() {
+                    return Err(format!(
+                        "string max_length ({max_length}) exceeds the maximum representable \
+                         length ({})",
+                        u32::MAX
+                    ));
+                }
+                Ok(())
             }
+            // `Seq`'s `max_len` is already a `u32` by construction (parsed as
+            // one), and a `u32`-bounded length model's denominator can never
+            // exceed `MAX_DENOMINATOR` (see the `String` case above), so
+            // there is nothing further to validate here. The `elem`
+            // expression, like `Config`, cannot be checked at macro-expansion
+            // time.
+            Model::Seq { .. } | Model::Config(_) => Ok(()),
         }
-        Ok(())
     }
 }
 
@@ -300,6 +421,36 @@ mod tests {
         }
         ; "unit enum"
     )]
+    #[test_case(
+        quote! {
+            #[derive(Encodeable)]
+            pub struct Reading {
+                #[encode(int(min = -10, max = 10))]
+                pub x: i32,
+            }
+        }
+        ; "int"
+    )]
+    #[test_case(
+        quote! {
+            #[derive(Encodeable)]
+            pub struct Reading {
+                #[encode(seq(max_len = 8, elem = minnow::FloatModel::new(0.0..=1.0, 1).unwrap()))]
+                pub samples: Vec<f64>,
+            }
+        }
+        ; "seq with elem"
+    )]
+    #[test_case(
+        quote! {
+            #[derive(Encodeable)]
+            pub struct Reading {
+                #[encode(seq(max_len = 8))]
+                pub flags: Vec<bool>,
+            }
+        }
+        ; "seq without elem"
+    )]
     fn parse(tokens: TokenStream) {
         let parsed: syn::DeriveInput = syn::parse2(tokens).unwrap();
         let _receiver = Receiver::from_derive_input(&parsed).unwrap();
@@ -319,7 +470,64 @@ mod tests {
             min: Number(0.0),
             max: Number(max),
             precision: Number(0),
+            clamping: false,
         };
         model.validate().is_ok()
+    }
+
+    /// The macro-time integer bounds check must agree with `IntModel::new`
+    /// exactly at the `MAX_DENOMINATOR` boundary. Unlike the float case this
+    /// is exact-integer arithmetic on both sides, so agreement is
+    /// straightforward — but still worth pinning down with a test.
+    #[test_case(4_611_686_018_427_387_902 => true; "largest width below the boundary is accepted")]
+    #[test_case(4_611_686_018_427_387_903 => false; "width equal to MAX_DENOMINATOR is rejected")]
+    fn int_boundary_agrees_with_runtime(max: i128) -> bool {
+        use super::{Model, Number};
+        let model = Model::Int {
+            min: Number(0),
+            max: Number(max),
+            clamping: false,
+        };
+        model.validate().is_ok()
+    }
+
+    #[test]
+    fn int_rejects_inverted_bounds() {
+        use super::{Model, Number};
+        let model = Model::Int {
+            min: Number(10),
+            max: Number(-10),
+            clamping: false,
+        };
+        assert!(model.validate().is_err());
+    }
+
+    #[test]
+    fn int_accepts_negative_range() {
+        use super::{Model, Number};
+        let model = Model::Int {
+            min: Number(-10),
+            max: Number(10),
+            clamping: false,
+        };
+        assert!(model.validate().is_ok());
+    }
+
+    #[test]
+    fn string_rejects_max_length_over_u32() {
+        use super::Model;
+        let model = Model::String {
+            max_length: u32::MAX as usize + 1,
+        };
+        assert!(model.validate().is_err());
+    }
+
+    #[test]
+    fn string_accepts_max_length_at_u32_max() {
+        use super::Model;
+        let model = Model::String {
+            max_length: u32::MAX as usize,
+        };
+        assert!(model.validate().is_ok());
     }
 }

--- a/minnow-derive/src/parse.rs
+++ b/minnow-derive/src/parse.rs
@@ -59,6 +59,15 @@ pub enum Model {
     String {
         max_length: usize,
     },
+    /// `#[encode(config = <expr>)]` — an arbitrary Rust expression evaluated
+    /// as the field's runtime config. This is the escape hatch every other
+    /// attribute form is sugar for (see [`Model::config_tokens`]); it accepts
+    /// any expression, so it **cannot** be validated at macro-expansion time.
+    /// An invalid or mistyped expression surfaces as an ordinary compile
+    /// error at its interpolation site (e.g. a type mismatch against
+    /// `<FieldType as EncodeableCustom>::Config`) rather than a clean
+    /// macro-time diagnostic.
+    Config(syn::Expr),
 }
 
 impl Model {
@@ -86,7 +95,13 @@ impl Model {
             Some(Self::String { max_length }) => {
                 quote! { minnow::StringModel::new( #max_length ) }
             }
-            None => quote! {()},
+            Some(Self::Config(expr)) => quote! { #expr },
+            // Fall back to `Default::default()` rather than a literal `()` so
+            // that a field whose type is a generic parameter with a
+            // non-`()` `Config` (constrained by a `Default` bound the derive
+            // adds — see `write.rs`) still works, not just concrete types
+            // that happen to use `Config = ()`.
+            None => quote! { ::core::default::Default::default() },
         }
     }
 

--- a/minnow-derive/src/parse/parse_enum.rs
+++ b/minnow-derive/src/parse/parse_enum.rs
@@ -1,3 +1,7 @@
+//! Attribute parsing for an enum's variants: each variant's payload fields
+//! (parsed the same way as a struct's, via [`super::parse_struct`]) plus an
+//! optional manual `#[encode(weight = N)]` discriminant override.
+
 use darling::{FromVariant, ast, export::syn};
 
 use super::{Field, parse_variant_attributes};

--- a/minnow-derive/src/parse/parse_enum.rs
+++ b/minnow-derive/src/parse/parse_enum.rs
@@ -1,17 +1,15 @@
-use darling::{FromField, FromVariant, export::syn};
+use darling::{FromVariant, ast, export::syn};
 
-use super::{Model, parse_variant_attributes};
-
-#[derive(FromField)]
-pub struct Field {
-    pub ty: syn::Type,
-}
+use super::{Field, parse_variant_attributes};
 
 pub struct Variant {
     pub ident: syn::Ident,
-    pub options: Option<Model>,
     pub weight: Option<u128>,
-    pub fields: darling::ast::Fields<Field>,
+    /// The variant's payload fields. Empty for a unit variant; `style ==
+    /// Tuple` for a tuple variant (`Foo(f64, bool)`); `style == Struct` for a
+    /// struct variant (`Foo { x: f64, y: bool }`). Each field carries its own
+    /// optional payload [`super::Model`] (see [`Field`]).
+    pub fields: ast::Fields<Field>,
 }
 
 impl FromVariant for Variant {
@@ -19,16 +17,48 @@ impl FromVariant for Variant {
         let mut errors = darling::Error::accumulator();
 
         let attributes = errors.handle(parse_variant_attributes(&variant.attrs));
-        let fields = errors.handle(darling::ast::Fields::try_from(&variant.fields));
+        let fields: Option<ast::Fields<Field>> =
+            errors.handle(ast::Fields::try_from(&variant.fields));
 
         errors.finish()?;
 
-        let (options, weight) = attributes.unwrap();
+        // `unwrap()` is safe: `errors.finish()` above already returned early
+        // if either `handle` call recorded an error, so both are `Some` here.
+        let (legacy_model, weight) = attributes.unwrap();
+        let mut fields = fields.unwrap();
+
+        // The legacy form puts a payload model directly on the variant
+        // (`#[encode(float(...))] Foo(f64)`), which only makes sense for a
+        // single-field tuple variant. Fold it into that field so every other
+        // stage of the pipeline only ever looks at field-level models.
+        if let Some(model) = legacy_model {
+            match fields.style {
+                ast::Style::Tuple if fields.fields.len() == 1 => {
+                    let field = &mut fields.fields[0];
+                    if field.model.is_some() {
+                        return Err(darling::Error::custom(
+                            "cannot combine a payload model attribute on the variant with an \
+                             `#[encode]` attribute on its field; put the attribute on the field \
+                             alone",
+                        )
+                        .with_span(&variant.ident));
+                    }
+                    field.model = Some(model);
+                }
+                _ => {
+                    return Err(darling::Error::custom(
+                        "a payload model attribute on the variant itself is only supported for \
+                         single-field tuple variants; put `#[encode]` attributes on the payload \
+                         fields instead",
+                    )
+                    .with_span(&variant.ident));
+                }
+            }
+        }
 
         Ok(Self {
             ident: variant.ident.clone(),
-            fields: fields.unwrap(),
-            options,
+            fields,
             weight,
         })
     }
@@ -78,6 +108,33 @@ mod tests {
             }
         }
         ; "tuple enum w model"
+    )]
+    #[test_case(
+        quote! {
+            #[derive(Debug, Encodeable)]
+            pub enum MyEnum {
+                A {
+                    #[encode(float(min = -10_000.0, max = 10_000.0, precision = 1))]
+                    x: f64,
+                    y: bool,
+                },
+                B,
+            }
+        }
+        ; "struct variant"
+    )]
+    #[test_case(
+        quote! {
+            #[derive(Debug, Encodeable)]
+            pub enum MyEnum {
+                A(
+                    #[encode(float(min = -10_000.0, max = 10_000.0, precision = 1))] f64,
+                    bool,
+                ),
+                B,
+            }
+        }
+        ; "multi field tuple variant"
     )]
     fn parse(tokens: TokenStream) {
         let parsed: syn::DeriveInput = syn::parse2(tokens).unwrap();

--- a/minnow-derive/src/parse/parse_struct.rs
+++ b/minnow-derive/src/parse/parse_struct.rs
@@ -1,3 +1,5 @@
+//! Attribute parsing for a struct's (or enum variant's) individual fields.
+
 use darling::{FromField, export::syn};
 use proc_macro2::TokenStream;
 

--- a/minnow-derive/src/process.rs
+++ b/minnow-derive/src/process.rs
@@ -1,3 +1,15 @@
+//! Stage 2 of the derive pipeline (`parse` → `process` → `write`): lower the
+//! parsed [`parse::Receiver`] into a [`Data`] tree shaped for codegen.
+//!
+//! Where [`crate::parse`] is concerned with attribute *syntax*, this stage is
+//! concerned with *structure*: a struct's fields and an enum variant's
+//! payload fields are both reduced to the same shape ([`StructStyle`]: unit /
+//! tuple / struct), so [`crate::write`] can treat a variant's payload exactly
+//! like an anonymous struct rather than special-casing it. This is also where
+//! an enum variant's discriminant weight is decided (the manual override from
+//! `#[encode(weight = N)]`, or `None` for the automatic payload-cardinality
+//! weight `crate::write` derives at codegen time).
+
 use crate::parse;
 
 mod process_enum;

--- a/minnow-derive/src/process.rs
+++ b/minnow-derive/src/process.rs
@@ -3,7 +3,7 @@ use crate::parse;
 mod process_enum;
 use process_enum::Variant;
 mod process_struct;
-pub use process_enum::{EnumData, Style as EnumStyle, Variant as EnumVariant};
+pub use process_enum::{EnumData, Variant as EnumVariant};
 pub use process_struct::{StructData, Style as StructStyle};
 
 pub fn process(receiver: parse::Receiver) -> Data {
@@ -20,6 +20,7 @@ impl From<parse::Receiver> for Data {
         match receiver.data {
             darling::ast::Data::Enum(variants) => Data::Enum(EnumData {
                 ident: receiver.ident,
+                generics: receiver.generics,
                 variants: variants.into_iter().map(Variant::from).collect(),
             }),
             darling::ast::Data::Struct(fields) => {

--- a/minnow-derive/src/process/process_enum.rs
+++ b/minnow-derive/src/process/process_enum.rs
@@ -1,67 +1,30 @@
 use darling::export::syn;
-use proc_macro2::TokenStream;
 
-use crate::parse::{self, Model};
+use crate::{parse, process::StructStyle};
 
 pub struct Variant {
     pub ident: syn::Ident,
-    pub style: Style,
+    /// The variant's payload, treated exactly like an anonymous struct's
+    /// fields — a unit variant has [`StructStyle::Unit`], a tuple variant
+    /// [`StructStyle::Tuple`], a struct variant [`StructStyle::Struct`].
+    pub style: StructStyle,
     /// A manual `#[encode(weight = N)]` discriminant weight, overriding the
     /// automatic (payload-cardinality) weight for this variant.
     pub weight_override: Option<u128>,
 }
 
-#[allow(clippy::large_enum_variant)]
-pub enum Style {
-    Tuple(Tuple),
-    // Struct(Struct),
-    Unit,
-}
-
-pub struct Tuple {
-    pub ty: syn::Type,
-    pub model: Option<Model>,
-}
-
-impl Tuple {
-    pub fn model(&self) -> TokenStream {
-        Model::config_tokens(self.model.as_ref())
-    }
-}
-
-// pub struct Struct {
-//     pub fields: Vec<parse::Field>,
-// }
-
 impl From<parse::Variant> for Variant {
     fn from(input: parse::Variant) -> Self {
-        let weight_override = input.weight;
-        match input.fields.style {
-            darling::ast::Style::Tuple => {
-                let tuple = Tuple {
-                    ty: input.fields.fields[0].ty.clone(),
-                    model: input.options,
-                };
-
-                let style = Style::Tuple(tuple);
-
-                Variant {
-                    ident: input.ident,
-                    style,
-                    weight_override,
-                }
-            }
-            darling::ast::Style::Struct => todo!(),
-            darling::ast::Style::Unit => Variant {
-                ident: input.ident,
-                style: Style::Unit,
-                weight_override,
-            },
+        Self {
+            ident: input.ident,
+            style: StructStyle::new(input.fields),
+            weight_override: input.weight,
         }
     }
 }
 
 pub struct EnumData {
     pub ident: syn::Ident,
+    pub generics: syn::Generics,
     pub variants: Vec<Variant>,
 }

--- a/minnow-derive/src/process/process_enum.rs
+++ b/minnow-derive/src/process/process_enum.rs
@@ -1,3 +1,8 @@
+//! Lowers a parsed enum's variants: each variant's payload is reduced to a
+//! [`StructStyle`], exactly like a struct's fields (see
+//! `crate::process::process_struct`), so a struct-style or multi-field tuple
+//! variant is just an anonymous struct to [`crate::write`].
+
 use darling::export::syn;
 
 use crate::{parse, process::StructStyle};

--- a/minnow-derive/src/process/process_struct.rs
+++ b/minnow-derive/src/process/process_struct.rs
@@ -1,3 +1,8 @@
+//! Lowers a parsed struct's fields into the shape [`crate::write`] codegens
+//! from: [`Style`] classifies it as unit / tuple / struct, matching the same
+//! classification used for an enum variant's payload (see
+//! `crate::process::process_enum`), so the two share one codegen path.
+
 use darling::{ast, export::syn};
 
 use crate::parse;

--- a/minnow-derive/src/process/process_struct.rs
+++ b/minnow-derive/src/process/process_struct.rs
@@ -31,7 +31,10 @@ pub enum Style {
 }
 
 impl Style {
-    fn new(fields: ast::Fields<parse::Field>) -> Self {
+    /// Lower a set of parsed fields to their [`Style`] — also used for an
+    /// enum variant's payload fields, which are treated as an anonymous
+    /// product exactly like a struct's (see `process_enum.rs`).
+    pub(crate) fn new(fields: ast::Fields<parse::Field>) -> Self {
         match fields.style {
             ast::Style::Tuple => Self::Tuple(fields.fields),
             ast::Style::Struct => Self::Struct(fields.fields),

--- a/minnow-derive/src/write.rs
+++ b/minnow-derive/src/write.rs
@@ -293,7 +293,7 @@ fn write_struct(struct_data: StructData) -> TokenStream {
                 #report_body
             }
 
-            fn encode_with_config<W>(&self, visitor: &mut minnow::EncodeVisitor<W>, _config: ()) -> std::io::Result<()>
+            fn encode_with_config<W>(&self, visitor: &mut minnow::EncodeVisitor<W>, _config: ()) -> ::core::result::Result<(), minnow::EncodeError>
             where
                 W: bitstream_io::BitWrite,
             {
@@ -487,7 +487,7 @@ fn write_enum(enum_data: EnumData) -> TokenStream {
                 minnow::SizeReport::sum(::std::vec![ #( #report_children ),* ])
             }
 
-            fn encode_with_config<W>(&self, visitor: &mut minnow::EncodeVisitor<W>, _config: ()) -> std::io::Result<()>
+            fn encode_with_config<W>(&self, visitor: &mut minnow::EncodeVisitor<W>, _config: ()) -> ::core::result::Result<(), minnow::EncodeError>
             where
                 W: bitstream_io::BitWrite {
                 let model = #model_ctor;

--- a/minnow-derive/src/write.rs
+++ b/minnow-derive/src/write.rs
@@ -1,14 +1,314 @@
+//! Lowering from a processed [`Data`] to the generated `EncodeableCustom`
+//! impl.
+//!
+//! A struct's fields and an enum variant's payload are both, mathematically,
+//! an anonymous *product* type (see `src/weight.rs` in the `minnow` crate):
+//! weight is the product of field weights, worst/best-case bits are the sum
+//! of field bits, and the report is a `SizeReport::product` of field reports.
+//! [`FieldSpec`]/[`Shape`]/[`product_fields`]/[`product_metrics`] capture that
+//! once, and both [`write_struct`] and [`write_enum`] build on top of it, so
+//! struct codegen and enum-variant-payload codegen cannot drift apart.
+
+use std::collections::HashSet;
+
 use darling::export::syn;
 use proc_macro2::TokenStream;
-use quote::{quote, quote_spanned};
+use quote::{format_ident, quote, quote_spanned};
 use syn::spanned::Spanned;
 
-use crate::process::{Data, EnumData, EnumStyle, StructData, StructStyle};
+use crate::{
+    parse,
+    process::{Data, EnumData, EnumVariant, StructData, StructStyle},
+};
 
 pub fn write(receiver: Data) -> TokenStream {
     match receiver {
         Data::Struct(struct_data) => write_struct(struct_data),
         Data::Enum(enum_data) => write_enum(enum_data),
+    }
+}
+
+/// How a product's fields are written back into source.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Shape {
+    /// A tuple constructor / pattern: `Self(a, b)`.
+    Positional,
+    /// A struct constructor / pattern: `Self { a, b }`.
+    Named,
+    /// No fields at all: `Self`.
+    Unit,
+}
+
+/// One field of a product type — a struct's fields, a tuple struct's fields,
+/// or an enum variant's payload fields — abstracted over how the field is
+/// named/bound so struct and enum-variant codegen can share one
+/// implementation.
+struct FieldSpec {
+    ty: syn::Type,
+    /// The runtime config expression passed to `encode_with_config` /
+    /// `decode_with_config` (see [`parse::Model::config_tokens`]).
+    model: TokenStream,
+    /// Whether the field carried an explicit `#[encode(...)]` attribute, as
+    /// opposed to falling back to `Default::default()`. Determines which
+    /// generic bounds a generic field needs — see [`add_generic_bounds`].
+    has_explicit_model: bool,
+    /// The name shown in the size-report tree, and used as the decode-side
+    /// struct-field key: the field's own identifier, or its positional
+    /// index.
+    name: String,
+    /// The identifier bound to this field's value: the field's own
+    /// identifier for named fields, else a synthesised `field_N`.
+    binding: syn::Ident,
+}
+
+impl FieldSpec {
+    fn new(index: usize, field: &parse::Field) -> Self {
+        let name = field
+            .ident
+            .as_ref()
+            .map_or_else(|| index.to_string(), ToString::to_string);
+        let binding = field
+            .ident
+            .clone()
+            .unwrap_or_else(|| format_ident!("field_{index}"));
+
+        Self {
+            ty: field.ty.clone(),
+            model: field.model(),
+            has_explicit_model: field.model.is_some(),
+            name,
+            binding,
+        }
+    }
+}
+
+/// Lower a [`StructStyle`] (a struct's fields, or an enum variant's payload)
+/// to its uniform [`Shape`] and [`FieldSpec`] list.
+fn product_fields(style: &StructStyle) -> (Shape, Vec<FieldSpec>) {
+    match style {
+        StructStyle::Tuple(fields) => (
+            Shape::Positional,
+            fields
+                .iter()
+                .enumerate()
+                .map(|(i, f)| FieldSpec::new(i, f))
+                .collect(),
+        ),
+        StructStyle::Struct(fields) => (
+            Shape::Named,
+            fields
+                .iter()
+                .enumerate()
+                .map(|(i, f)| FieldSpec::new(i, f))
+                .collect(),
+        ),
+        StructStyle::Unit => (Shape::Unit, Vec::new()),
+    }
+}
+
+/// The `weight`, `worst_case_bits`, `best_case_bits`, and `report`
+/// expressions for a product of fields.
+struct ProductMetrics {
+    /// A `minnow::Weight` expression: the product rule (`∏ W(fieldᵢ)`).
+    weight: TokenStream,
+    /// An `f64` expression: the sum of per-field worst-case bits.
+    worst_case_bits: TokenStream,
+    /// An `f64` expression: the sum of per-field best-case bits.
+    best_case_bits: TokenStream,
+    /// A `minnow::SizeReport` expression: `SizeReport::product` of the
+    /// per-field reports, each named.
+    report: TokenStream,
+}
+
+fn product_metrics(fields: &[FieldSpec]) -> ProductMetrics {
+    let weight_terms = fields.iter().map(|f| {
+        let ty = &f.ty;
+        let model = &f.model;
+        quote_spanned! {ty.span()=>
+            * <#ty as minnow::EncodeableCustom>::weight(&(#model))
+        }
+    });
+    let bits_terms = fields.iter().map(|f| {
+        let ty = &f.ty;
+        let model = &f.model;
+        quote_spanned! {ty.span()=>
+            + <#ty as minnow::EncodeableCustom>::worst_case_bits(&(#model))
+        }
+    });
+    let best_bits_terms = fields.iter().map(|f| {
+        let ty = &f.ty;
+        let model = &f.model;
+        quote_spanned! {ty.span()=>
+            + <#ty as minnow::EncodeableCustom>::best_case_bits(&(#model))
+        }
+    });
+    let report_children = fields.iter().map(|f| {
+        let ty = &f.ty;
+        let model = &f.model;
+        let name = &f.name;
+        quote_spanned! {ty.span()=>
+            <#ty as minnow::EncodeableCustom>::report(&(#model)).with_name(#name)
+        }
+    });
+
+    ProductMetrics {
+        // Product rule: the type's cardinality is the product of its fields'.
+        weight: quote! { minnow::Weight::ONE #( #weight_terms )* },
+        worst_case_bits: quote! { 0.0_f64 #( #bits_terms )* },
+        best_case_bits: quote! { 0.0_f64 #( #best_bits_terms )* },
+        report: quote! { minnow::SizeReport::product(::std::vec![ #( #report_children ),* ]) },
+    }
+}
+
+/// Build the encode statements for a product's fields, given a closure that
+/// produces the `&FieldType` expression accessing field `i`.
+fn encode_stmts(
+    fields: &[FieldSpec],
+    accessor: impl Fn(usize, &FieldSpec) -> TokenStream,
+) -> TokenStream {
+    fields
+        .iter()
+        .enumerate()
+        .map(|(i, f)| {
+            let ty = &f.ty;
+            let model = &f.model;
+            let access = accessor(i, f);
+            quote_spanned! {ty.span()=>
+                minnow::EncodeableCustom::encode_with_config(#access, visitor, #model)?;
+            }
+        })
+        .collect()
+}
+
+/// Build the constructor expression for decoding a product: `path`,
+/// `path(...)`, or `path { ... }` depending on `shape`, decoding each field
+/// in order.
+fn decode_ctor(path: &TokenStream, shape: Shape, fields: &[FieldSpec]) -> TokenStream {
+    let decoded = fields.iter().map(|f| {
+        let ty = &f.ty;
+        let model = &f.model;
+        quote_spanned! {ty.span()=>
+            <#ty as minnow::EncodeableCustom>::decode_with_config(visitor, #model)?
+        }
+    });
+    match shape {
+        Shape::Unit => quote! { #path },
+        Shape::Positional => quote! { #path( #( #decoded ),* ) },
+        Shape::Named => {
+            let bindings = fields.iter().map(|f| &f.binding);
+            quote! { #path { #( #bindings: #decoded ),* } }
+        }
+    }
+}
+
+/// Add the [`minnow::EncodeableCustom`] bounds a generated impl needs on its
+/// type parameters.
+///
+/// For every type parameter used as *some field's type directly* (`inner:
+/// T`), this adds `T: minnow::EncodeableCustom`, plus `<T as
+/// minnow::EncodeableCustom>::Config: Default` when that field carries no
+/// explicit `#[encode(...)]` attribute (its config then lowers to
+/// `Default::default()` — see [`parse::Model::config_tokens`]).
+///
+/// This only recognises a field whose type is *exactly* a bare type
+/// parameter; a field that merely mentions one (e.g. `Option<T>`) needs its
+/// bound spelled out by hand on the type declaration, which the where-clause
+/// this appends to still carries through untouched.
+fn add_generic_bounds(generics: &mut syn::Generics, fields: &[FieldSpec]) {
+    let type_params: HashSet<syn::Ident> =
+        generics.type_params().map(|tp| tp.ident.clone()).collect();
+    if type_params.is_empty() {
+        return;
+    }
+
+    let mut seen = HashSet::new();
+    let where_clause = generics.make_where_clause();
+    for field in fields {
+        let syn::Type::Path(type_path) = &field.ty else {
+            continue;
+        };
+        let Some(ident) = type_path.path.get_ident() else {
+            continue;
+        };
+        if !type_params.contains(ident) || !seen.insert(ident.clone()) {
+            continue;
+        }
+
+        where_clause
+            .predicates
+            .push(syn::parse_quote! { #ident: minnow::EncodeableCustom });
+        if !field.has_explicit_model {
+            where_clause.predicates.push(syn::parse_quote! {
+                <#ident as minnow::EncodeableCustom>::Config: ::core::default::Default
+            });
+        }
+    }
+}
+
+fn write_struct(struct_data: StructData) -> TokenStream {
+    let (shape, fields) = product_fields(&struct_data.fields);
+    let metrics = product_metrics(&fields);
+
+    let encode_body = encode_stmts(&fields, |i, f| match shape {
+        Shape::Named => {
+            let ident = &f.binding;
+            quote! { &self.#ident }
+        }
+        Shape::Positional => {
+            let idx = syn::Index::from(i);
+            quote! { &self.#idx }
+        }
+        Shape::Unit => TokenStream::new(),
+    });
+
+    let decode_ctor_expr = decode_ctor(&quote! { Self }, shape, &fields);
+
+    let mut generics = struct_data.generics;
+    add_generic_bounds(&mut generics, &fields);
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    let ident = struct_data.ident;
+    let weight_body = metrics.weight;
+    let worst_case_body = metrics.worst_case_bits;
+    let best_case_body = metrics.best_case_bits;
+    let report_body = metrics.report;
+
+    quote! {
+        impl #impl_generics minnow::EncodeableCustom for #ident #ty_generics #where_clause {
+            type Config = ();
+
+            fn weight(_config: &Self::Config) -> minnow::Weight {
+                #weight_body
+            }
+
+            fn worst_case_bits(_config: &Self::Config) -> f64 {
+                #worst_case_body
+            }
+
+            fn best_case_bits(_config: &Self::Config) -> f64 {
+                #best_case_body
+            }
+
+            fn report(_config: &Self::Config) -> minnow::SizeReport {
+                #report_body
+            }
+
+            fn encode_with_config<W>(&self, visitor: &mut minnow::EncodeVisitor<W>, _config: ()) -> std::io::Result<()>
+            where
+                W: bitstream_io::BitWrite,
+            {
+                #encode_body
+                Ok(())
+            }
+
+            fn decode_with_config<R>(visitor: &mut minnow::DecodeVisitor<R>, _config: ()) -> ::core::result::Result<Self, minnow::DecodeError>
+            where
+                R: bitstream_io::BitRead,
+                Self: Sized,
+            {
+                Ok(#decode_ctor_expr)
+            }
+        }
     }
 }
 
@@ -35,7 +335,7 @@ struct VariantParts {
     report_child: TokenStream,
 }
 
-fn variant_parts(index: usize, variant: &crate::process::EnumVariant) -> VariantParts {
+fn variant_parts(index: usize, variant: &EnumVariant) -> VariantParts {
     let ident = &variant.ident;
     // A checked conversion rather than `as`: a panic in a proc macro is a
     // compile error, so an absurd variant count fails loudly instead of
@@ -44,71 +344,67 @@ fn variant_parts(index: usize, variant: &crate::process::EnumVariant) -> Variant
     let idx = syn::Index::from(index);
     let name = ident.to_string();
 
-    // The manual override, as a `u128` literal, if present.
-    let override_weight = variant.weight_override.map(|w| quote! { #w });
+    let (shape, fields) = product_fields(&variant.style);
+    let metrics = product_metrics(&fields);
 
-    match &variant.style {
-        EnumStyle::Tuple(tuple) => {
-            let ty = &tuple.ty;
-            let ty_span = ty.span();
-            let model = tuple.model();
-
-            let payload_weight = quote! {
-                <#ty as minnow::EncodeableCustom>::weight(&(#model))
-            };
-            let discriminant_weight =
-                override_weight.unwrap_or_else(|| quote! { #payload_weight.get() });
-
-            VariantParts {
-                encode_arm: quote_spanned! {ty_span=>
-                    Self::#ident(x) => {
-                        visitor.encode_one(model, &#symbol)?;
-                        minnow::EncodeableCustom::encode_with_config(x, visitor, #model)
-                    }
-                },
-                decode_arm: quote_spanned! {ty_span=>
-                    #symbol => ::core::result::Result::Ok(Self::#ident(
-                        <#ty as minnow::EncodeableCustom>::decode_with_config(visitor, #model)?,
-                    )),
-                },
-                discriminant_weight,
-                cardinality: payload_weight,
-                payload_bits: quote! {
-                    <#ty as minnow::EncodeableCustom>::worst_case_bits(&(#model))
-                },
-                payload_best_bits: quote! {
-                    <#ty as minnow::EncodeableCustom>::best_case_bits(&(#model))
-                },
-                report_child: quote! {
-                    minnow::SizeReport::enum_variant(
-                        #name,
-                        model.discriminant_bits(#idx),
-                        <#ty as minnow::EncodeableCustom>::report(&(#model)),
-                    )
-                },
-            }
+    let path = quote! { Self::#ident };
+    let pattern = match shape {
+        Shape::Unit => path.clone(),
+        Shape::Positional => {
+            let bindings = fields.iter().map(|f| &f.binding);
+            quote! { #path( #( #bindings ),* ) }
         }
-        EnumStyle::Unit => {
-            let discriminant_weight = override_weight.unwrap_or_else(|| quote! { 1u128 });
-
-            VariantParts {
-                encode_arm: quote! {
-                    Self::#ident => visitor.encode_one(model, &#symbol),
-                },
-                decode_arm: quote! {
-                    #symbol => ::core::result::Result::Ok(Self::#ident),
-                },
-                discriminant_weight,
-                // A unit variant always has exactly one value, regardless of any
-                // discriminant-weight override.
-                cardinality: quote! { minnow::Weight::ONE },
-                payload_bits: quote! { 0.0_f64 },
-                payload_best_bits: quote! { 0.0_f64 },
-                report_child: quote! {
-                    minnow::SizeReport::leaf(model.discriminant_bits(#idx)).with_name(#name)
-                },
-            }
+        Shape::Named => {
+            let bindings = fields.iter().map(|f| &f.binding);
+            quote! { #path { #( #bindings ),* } }
         }
+    };
+
+    // Under `match self { ... }` with `self: &Self`, every bound field name is
+    // already a `&FieldType` thanks to match ergonomics, so it can be passed
+    // straight through as the encode accessor.
+    let encode_field_stmts = encode_stmts(&fields, |_, f| {
+        let binding = &f.binding;
+        quote! { #binding }
+    });
+    let encode_arm = quote! {
+        #pattern => {
+            visitor.encode_one(model, &#symbol)?;
+            #encode_field_stmts
+            Ok(())
+        }
+    };
+
+    let decode_ctor_expr = decode_ctor(&path, shape, &fields);
+    let decode_arm = quote! {
+        #symbol => ::core::result::Result::Ok(#decode_ctor_expr),
+    };
+
+    // The manual override, as a `u128` literal, if present; else the
+    // payload's true cardinality (wrapped in parens: `payload_weight` is a
+    // `*`/`+` expression tree, and `.get()` must apply to the whole thing).
+    let payload_weight = &metrics.weight;
+    let discriminant_weight = variant
+        .weight_override
+        .map_or_else(|| quote! { (#payload_weight).get() }, |w| quote! { #w });
+
+    let payload_report = &metrics.report;
+    let report_child = quote! {
+        minnow::SizeReport::enum_variant(
+            #name,
+            model.discriminant_bits(#idx),
+            #payload_report,
+        )
+    };
+
+    VariantParts {
+        encode_arm,
+        decode_arm,
+        discriminant_weight,
+        cardinality: metrics.weight,
+        payload_bits: metrics.worst_case_bits,
+        payload_best_bits: metrics.best_case_bits,
+        report_child,
     }
 }
 
@@ -121,6 +417,15 @@ fn write_enum(enum_data: EnumData) -> TokenStream {
         .collect();
 
     let ident = enum_data.ident;
+
+    let all_fields: Vec<FieldSpec> = enum_data
+        .variants
+        .iter()
+        .flat_map(|v| product_fields(&v.style).1)
+        .collect();
+    let mut generics = enum_data.generics;
+    add_generic_bounds(&mut generics, &all_fields);
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
     let encode_arms = parts.iter().map(|p| &p.encode_arm);
     let decode_arms = parts.iter().map(|p| &p.decode_arm);
@@ -155,7 +460,7 @@ fn write_enum(enum_data: EnumData) -> TokenStream {
     let report_children = parts.iter().map(|p| &p.report_child);
 
     quote! {
-        impl minnow::EncodeableCustom for #ident {
+        impl #impl_generics minnow::EncodeableCustom for #ident #ty_generics #where_clause {
             type Config = ();
 
             fn weight(_config: &Self::Config) -> minnow::Weight {
@@ -201,199 +506,6 @@ fn write_enum(enum_data: EnumData) -> TokenStream {
                     other => ::core::result::Result::Err(minnow::DecodeError::InvalidSymbol { symbol: u128::from(other) }),
                 }
             }
-        }
-    }
-}
-
-/// The `weight`, `worst_case_bits`, `best_case_bits` and `report` method bodies
-/// for a struct.
-struct StructMetrics {
-    weight: TokenStream,
-    worst_case_bits: TokenStream,
-    best_case_bits: TokenStream,
-    report: TokenStream,
-}
-
-fn struct_metrics(fields: &StructStyle) -> StructMetrics {
-    // Collect per-field `(type, model, name)` for the metric methods.
-    let entries: Vec<(TokenStream, TokenStream, String)> = match fields {
-        StructStyle::Tuple(fields) => fields
-            .iter()
-            .enumerate()
-            .map(|(i, field)| {
-                let ty = &field.ty;
-                (quote! { #ty }, field.model(), i.to_string())
-            })
-            .collect(),
-        StructStyle::Struct(fields) => fields
-            .iter()
-            .map(|field| {
-                let ty = &field.ty;
-                let name = field.ident.as_ref().unwrap().to_string();
-                (quote! { #ty }, field.model(), name)
-            })
-            .collect(),
-        StructStyle::Unit => Vec::new(),
-    };
-
-    let weight_terms = entries.iter().map(|(ty, model, _)| {
-        quote! { * <#ty as minnow::EncodeableCustom>::weight(&(#model)) }
-    });
-    let bits_terms = entries.iter().map(|(ty, model, _)| {
-        quote! { + <#ty as minnow::EncodeableCustom>::worst_case_bits(&(#model)) }
-    });
-    let best_bits_terms = entries.iter().map(|(ty, model, _)| {
-        quote! { + <#ty as minnow::EncodeableCustom>::best_case_bits(&(#model)) }
-    });
-    let report_children = entries.iter().map(|(ty, model, name)| {
-        quote! {
-            <#ty as minnow::EncodeableCustom>::report(&(#model)).with_name(#name)
-        }
-    });
-
-    StructMetrics {
-        // Product rule: the type's cardinality is the product of its fields'.
-        weight: quote! { minnow::Weight::ONE #( #weight_terms )* },
-        worst_case_bits: quote! { 0.0_f64 #( #bits_terms )* },
-        best_case_bits: quote! { 0.0_f64 #( #best_bits_terms )* },
-        report: quote! { minnow::SizeReport::product(::std::vec![ #( #report_children ),* ]) },
-    }
-}
-
-#[allow(clippy::too_many_lines)]
-fn write_struct(struct_data: StructData) -> TokenStream {
-    let encode_block: TokenStream = match &struct_data.fields {
-        StructStyle::Tuple(fields) => {
-            let encode_fields: TokenStream = fields
-                .iter()
-                .enumerate()
-                .map(|(i, field)| {
-                    let model = field.model();
-                    let i = syn::Index::from(i);
-                    quote! {
-                        minnow::EncodeableCustom::encode_with_config(& self. #i, visitor, #model)?;
-                    }
-                })
-                .collect();
-            quote! {
-                fn encode_with_config<W>(&self, visitor: &mut minnow::EncodeVisitor<W>, _config: ()) -> std::io::Result<()>
-                where
-                    W: bitstream_io::BitWrite,
-                {
-                    #encode_fields
-                    Ok(())
-                }
-            }
-        }
-        StructStyle::Struct(fields) => {
-            let encode_fields: TokenStream = fields
-                .iter()
-                .map(|field| {
-                    let ident = field.ident.as_ref().unwrap();
-                    let model = field.model();
-                    quote! {
-                        minnow::EncodeableCustom::encode_with_config(& self. #ident, visitor, #model)?;
-                    }
-                })
-                .collect();
-            quote! {
-                fn encode_with_config<W>(&self, visitor: &mut minnow::EncodeVisitor<W>, _config: ()) -> std::io::Result<()>
-                where
-                    W: bitstream_io::BitWrite,
-                {
-                    #encode_fields
-                    Ok(())
-                }
-            }
-        }
-        StructStyle::Unit => TokenStream::default(),
-    };
-
-    let decode_block: TokenStream = match &struct_data.fields {
-        StructStyle::Tuple(fields) => {
-            let decode_fields: TokenStream = fields
-                .iter()
-                .map(|field| {
-                    let model = field.model();
-                    let ty = &field.ty;
-                    quote! {
-                        <#ty as minnow::EncodeableCustom>::decode_with_config(visitor, #model)?,
-                    }
-                })
-                .collect();
-
-            quote! {
-                fn decode_with_config<R>(visitor: &mut minnow::DecodeVisitor<R>, config: ()) -> ::core::result::Result<Self, minnow::DecodeError>
-                where
-                    R: bitstream_io::BitRead,
-                    Self: Sized,
-                {
-                    Ok(Self (
-                        #decode_fields
-                    ))
-                }
-            }
-        }
-        StructStyle::Struct(fields) => {
-            let decode_fields: TokenStream = fields
-                .iter()
-                .map(|field| {
-                    let ident = field.ident.as_ref().unwrap();
-                    let ty = &field.ty;
-                    let model = field.model();
-                    quote! {
-                        #ident : <#ty as minnow::EncodeableCustom>::decode_with_config(visitor, #model )?,
-                    }
-                })
-                .collect();
-
-            quote! {
-                fn decode_with_config<R>(visitor: &mut minnow::DecodeVisitor<R>, config: ()) -> ::core::result::Result<Self, minnow::DecodeError>
-                where
-                    R: bitstream_io::BitRead,
-                    Self: Sized,
-                {
-                    Ok(Self {
-                        #decode_fields
-                    })
-                }
-            }
-        }
-        StructStyle::Unit => todo!(),
-    };
-
-    let metrics = struct_metrics(&struct_data.fields);
-    let weight_body = metrics.weight;
-    let worst_case_body = metrics.worst_case_bits;
-    let best_case_body = metrics.best_case_bits;
-    let report_body = metrics.report;
-
-    let ident = struct_data.ident;
-    let generics = struct_data.generics;
-
-    quote! {
-        impl minnow::EncodeableCustom for #ident #generics {
-            type Config = ();
-
-            fn weight(_config: &Self::Config) -> minnow::Weight {
-                #weight_body
-            }
-
-            fn worst_case_bits(_config: &Self::Config) -> f64 {
-                #worst_case_body
-            }
-
-            fn best_case_bits(_config: &Self::Config) -> f64 {
-                #best_case_body
-            }
-
-            fn report(_config: &Self::Config) -> minnow::SizeReport {
-                #report_body
-            }
-
-            #encode_block
-
-            #decode_block
         }
     }
 }

--- a/minnow-derive/tests/trybuild.rs
+++ b/minnow-derive/tests/trybuild.rs
@@ -23,13 +23,14 @@ fn ui() {
 
     // The checked-in `.stderr` snapshots pin rustc's exact diagnostic
     // rendering (span underlines, box-drawing characters), generated on this
-    // workspace's stable-channel toolchain. This workspace's CI `test` job
-    // also runs the pinned MSRV toolchain, whose diagnostic formatting can
-    // differ — skip the stderr-sensitive checks there rather than fail for
-    // reasons unrelated to the macro's correctness. If `rustc --version`
-    // can't be determined, fail open and run the checks anyway (the
-    // behaviour every non-CI/local run gets).
-    if !is_msrv_toolchain() {
+    // workspace's current stable toolchain. CI also runs the pinned MSRV
+    // toolchain (`test (1.85)`) and a nightly (the coverage job), whose
+    // diagnostic wording differs — skip the stderr-sensitive checks on any
+    // non-current-stable toolchain rather than fail for reasons unrelated to
+    // the macro's correctness. If `rustc --version` can't be determined,
+    // fail open and run the checks anyway (the behaviour every non-CI/local
+    // run gets).
+    if is_snapshot_toolchain() {
         t.compile_fail("tests/ui/fail/*.rs");
     }
 
@@ -38,16 +39,19 @@ fn ui() {
     t.pass("tests/ui/pass/*.rs");
 }
 
-/// Best-effort detection of this workspace's pinned MSRV toolchain (see the
-/// `rust-version` key in `Cargo.toml`), so the stderr-snapshotted half of
-/// [`ui`] can be skipped there. Returns `false` (fail open) if the version
-/// can't be determined.
-fn is_msrv_toolchain() -> bool {
+/// Best-effort detection of a toolchain whose diagnostics match the
+/// checked-in `.stderr` snapshots: a *stable* rustc that is not this
+/// workspace's pinned MSRV (see the `rust-version` key in `Cargo.toml`).
+/// Nightly/beta compilers and the MSRV word their diagnostics differently.
+/// Returns `true` (fail open, run the checks) if the version can't be
+/// determined — the behaviour every local run gets.
+fn is_snapshot_toolchain() -> bool {
     const MSRV: &str = "1.85";
 
     let rustc = std::env::var_os("RUSTC").unwrap_or_else(|| "rustc".into());
     let Ok(output) = std::process::Command::new(rustc).arg("--version").output() else {
-        return false;
+        return true;
     };
-    String::from_utf8_lossy(&output.stdout).contains(MSRV)
+    let version = String::from_utf8_lossy(&output.stdout).into_owned();
+    !version.contains("nightly") && !version.contains("beta") && !version.contains(MSRV)
 }

--- a/minnow-derive/tests/trybuild.rs
+++ b/minnow-derive/tests/trybuild.rs
@@ -1,0 +1,53 @@
+//! UI tests for the derive macro's diagnostics.
+//!
+//! Each fixture under `tests/ui/fail/` must fail to compile with a clean
+//! diagnostic — never a macro panic (`todo!()`, `unwrap()`, `assert!()`
+//! reachable from user input). The checked-in `.stderr` snapshots were
+//! generated on this workspace's pinned stable toolchain; `trybuild`
+//! compares against them exactly, so a toolchain upgrade that changes
+//! diagnostic wording (rustc's own, or `darling`'s) will need
+//! `TRYBUILD=overwrite cargo test -p minnow-derive --test trybuild` to
+//! regenerate them — re-diff the output when you do, to confirm the
+//! diagnostic is still a clean one (no "panicked at") rather than rubber-
+//! stamping a regression. Run this test only on the stable CI job for that
+//! reason; MSRV/nightly jobs should skip it.
+//!
+//! Fixtures under `tests/ui/pass/` must compile, exercising the newer
+//! attribute forms (`config = <expr>`, struct/multi-field-tuple variants,
+//! generics) as an extra compile-time smoke test alongside the `tests/*.rs`
+//! integration tests.
+
+#[test]
+fn ui() {
+    let t = trybuild::TestCases::new();
+
+    // The checked-in `.stderr` snapshots pin rustc's exact diagnostic
+    // rendering (span underlines, box-drawing characters), generated on this
+    // workspace's stable-channel toolchain. This workspace's CI `test` job
+    // also runs the pinned MSRV toolchain, whose diagnostic formatting can
+    // differ — skip the stderr-sensitive checks there rather than fail for
+    // reasons unrelated to the macro's correctness. If `rustc --version`
+    // can't be determined, fail open and run the checks anyway (the
+    // behaviour every non-CI/local run gets).
+    if !is_msrv_toolchain() {
+        t.compile_fail("tests/ui/fail/*.rs");
+    }
+
+    // The pass fixtures carry no stderr snapshot, so they must keep
+    // compiling on every toolchain in the matrix.
+    t.pass("tests/ui/pass/*.rs");
+}
+
+/// Best-effort detection of this workspace's pinned MSRV toolchain (see the
+/// `rust-version` key in `Cargo.toml`), so the stderr-snapshotted half of
+/// [`ui`] can be skipped there. Returns `false` (fail open) if the version
+/// can't be determined.
+fn is_msrv_toolchain() -> bool {
+    const MSRV: &str = "1.85";
+
+    let rustc = std::env::var_os("RUSTC").unwrap_or_else(|| "rustc".into());
+    let Ok(output) = std::process::Command::new(rustc).arg("--version").output() else {
+        return false;
+    };
+    String::from_utf8_lossy(&output.stdout).contains(MSRV)
+}

--- a/minnow-derive/tests/ui/fail/config_garbage_expr.rs
+++ b/minnow-derive/tests/ui/fail/config_garbage_expr.rs
@@ -1,0 +1,13 @@
+// `config = <expr>` accepts arbitrary Rust expressions, so it cannot be
+// validated at macro-expansion time — but genuinely malformed token trees
+// must still fail cleanly (a `syn`/`darling` parse error), not panic the
+// macro.
+use minnow_derive::Encodeable;
+
+#[derive(Encodeable)]
+pub struct Bad {
+    #[encode(config = +++)]
+    x: f64,
+}
+
+fn main() {}

--- a/minnow-derive/tests/ui/fail/config_garbage_expr.stderr
+++ b/minnow-derive/tests/ui/fail/config_garbage_expr.stderr
@@ -1,0 +1,5 @@
+error: expected an expression
+ --> tests/ui/fail/config_garbage_expr.rs:9:23
+  |
+9 |     #[encode(config = +++)]
+  |                       ^

--- a/minnow-derive/tests/ui/fail/duplicate_field_attr.rs
+++ b/minnow-derive/tests/ui/fail/duplicate_field_attr.rs
@@ -1,0 +1,13 @@
+// A field with two `#[encode(...)]` attributes is ambiguous: which model
+// applies? Must be a clean compile error, not a silent "last one wins" or a
+// panic.
+use minnow_derive::Encodeable;
+
+#[derive(Encodeable)]
+pub struct Bad {
+    #[encode(float(min = 0.0, max = 1.0, precision = 0))]
+    #[encode(float(min = 0.0, max = 2.0, precision = 0))]
+    x: f64,
+}
+
+fn main() {}

--- a/minnow-derive/tests/ui/fail/duplicate_field_attr.stderr
+++ b/minnow-derive/tests/ui/fail/duplicate_field_attr.stderr
@@ -1,0 +1,5 @@
+error: Unexpected encode attribute. Each field should have a single attribute only
+ --> tests/ui/fail/duplicate_field_attr.rs:9:5
+  |
+9 |     #[encode(float(min = 0.0, max = 2.0, precision = 0))]
+  |     ^

--- a/minnow-derive/tests/ui/fail/inverted_float_bounds.rs
+++ b/minnow-derive/tests/ui/fail/inverted_float_bounds.rs
@@ -1,0 +1,11 @@
+// `min` above `max` is nonsensical and must be rejected at macro-expansion
+// time, not produce a model that panics at runtime.
+use minnow_derive::Encodeable;
+
+#[derive(Encodeable)]
+pub struct Bad {
+    #[encode(float(min = 10.0, max = -10.0, precision = 0))]
+    x: f64,
+}
+
+fn main() {}

--- a/minnow-derive/tests/ui/fail/inverted_float_bounds.stderr
+++ b/minnow-derive/tests/ui/fail/inverted_float_bounds.stderr
@@ -1,0 +1,5 @@
+error: float model lower bound (10) must not exceed the upper bound (-10)
+ --> tests/ui/fail/inverted_float_bounds.rs:7:5
+  |
+7 |     #[encode(float(min = 10.0, max = -10.0, precision = 0))]
+  |     ^

--- a/minnow-derive/tests/ui/fail/oversized_float_denominator.rs
+++ b/minnow-derive/tests/ui/fail/oversized_float_denominator.rs
@@ -1,0 +1,12 @@
+// A float model whose denominator exceeds the arithmetic coder's precision
+// bound must be rejected at macro-expansion time (mirroring
+// `FloatModel::new`), not silently corrupt round-trips at runtime.
+use minnow_derive::Encodeable;
+
+#[derive(Encodeable)]
+pub struct Bad {
+    #[encode(float(min = 0.0, max = 9223372036854775808.0, precision = 0))]
+    x: f64,
+}
+
+fn main() {}

--- a/minnow-derive/tests/ui/fail/oversized_float_denominator.stderr
+++ b/minnow-derive/tests/ui/fail/oversized_float_denominator.stderr
@@ -1,0 +1,5 @@
+error: float model denominator (9223372036854775809) exceeds the maximum (4611686018427387903) permitted at precision 64; narrow the range or reduce the precision
+ --> tests/ui/fail/oversized_float_denominator.rs:8:5
+  |
+8 |     #[encode(float(min = 0.0, max = 9223372036854775808.0, precision = 0))]
+  |     ^

--- a/minnow-derive/tests/ui/fail/unsupported_union.rs
+++ b/minnow-derive/tests/ui/fail/unsupported_union.rs
@@ -1,0 +1,11 @@
+// The derive only supports structs and enums; a `union` must fail cleanly
+// (rejected by `darling`'s `FromDeriveInput`), not panic.
+use minnow_derive::Encodeable;
+
+#[derive(Encodeable)]
+pub union Bad {
+    x: f64,
+    y: u32,
+}
+
+fn main() {}

--- a/minnow-derive/tests/ui/fail/unsupported_union.stderr
+++ b/minnow-derive/tests/ui/fail/unsupported_union.stderr
@@ -1,0 +1,7 @@
+error: Unions are not supported
+ --> tests/ui/fail/unsupported_union.rs:5:10
+  |
+5 | #[derive(Encodeable)]
+  |          ^^^^^^^^^^
+  |
+  = note: this error originates in the derive macro `Encodeable` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/minnow-derive/tests/ui/fail/variant_and_field_model_conflict.rs
+++ b/minnow-derive/tests/ui/fail/variant_and_field_model_conflict.rs
@@ -1,0 +1,12 @@
+// Combining the legacy variant-level model with a field-level attribute on
+// the same (sole) field is ambiguous and must be rejected, not silently pick
+// one.
+use minnow_derive::Encodeable;
+
+#[derive(Encodeable)]
+pub enum Bad {
+    #[encode(float(min = 0.0, max = 1.0, precision = 0))]
+    A(#[encode(float(min = 0.0, max = 2.0, precision = 0))] f64),
+}
+
+fn main() {}

--- a/minnow-derive/tests/ui/fail/variant_and_field_model_conflict.stderr
+++ b/minnow-derive/tests/ui/fail/variant_and_field_model_conflict.stderr
@@ -1,0 +1,5 @@
+error: cannot combine a payload model attribute on the variant with an `#[encode]` attribute on its field; put the attribute on the field alone
+ --> tests/ui/fail/variant_and_field_model_conflict.rs:9:5
+  |
+9 |     A(#[encode(float(min = 0.0, max = 2.0, precision = 0))] f64),
+  |     ^

--- a/minnow-derive/tests/ui/fail/variant_level_model_on_multi_field_tuple.rs
+++ b/minnow-derive/tests/ui/fail/variant_level_model_on_multi_field_tuple.rs
@@ -1,0 +1,14 @@
+// The legacy variant-level payload model (`#[encode(float(...))] Foo(f64)`)
+// only makes sense for a single-field tuple variant. On a multi-field
+// tuple variant it used to be silently applied to just the first field and
+// ignore the rest; now it must be a clean compile error instead, pointing
+// users at putting `#[encode]` attributes on the individual fields.
+use minnow_derive::Encodeable;
+
+#[derive(Encodeable)]
+pub enum Bad {
+    #[encode(float(min = 0.0, max = 1.0, precision = 0))]
+    A(f64, bool),
+}
+
+fn main() {}

--- a/minnow-derive/tests/ui/fail/variant_level_model_on_multi_field_tuple.stderr
+++ b/minnow-derive/tests/ui/fail/variant_level_model_on_multi_field_tuple.stderr
@@ -1,0 +1,5 @@
+error: a payload model attribute on the variant itself is only supported for single-field tuple variants; put `#[encode]` attributes on the payload fields instead
+  --> tests/ui/fail/variant_level_model_on_multi_field_tuple.rs:11:5
+   |
+11 |     A(f64, bool),
+   |     ^

--- a/minnow-derive/tests/ui/fail/zero_weight.rs
+++ b/minnow-derive/tests/ui/fail/zero_weight.rs
@@ -1,0 +1,12 @@
+// `weight = 0` would make a variant unencodable (a zero-width interval);
+// must be a clean compile error.
+use minnow_derive::Encodeable;
+
+#[derive(Encodeable)]
+pub enum Bad {
+    #[encode(weight = 0)]
+    A,
+    B,
+}
+
+fn main() {}

--- a/minnow-derive/tests/ui/fail/zero_weight.stderr
+++ b/minnow-derive/tests/ui/fail/zero_weight.stderr
@@ -1,0 +1,5 @@
+error: `weight` must be at least 1
+ --> tests/ui/fail/zero_weight.rs:7:5
+  |
+7 |     #[encode(weight = 0)]
+  |     ^

--- a/minnow-derive/tests/ui/pass/config_expr.rs
+++ b/minnow-derive/tests/ui/pass/config_expr.rs
@@ -1,0 +1,11 @@
+// `#[encode(config = <expr>)]` accepts an arbitrary expression producing the
+// field's config.
+use minnow_derive::Encodeable;
+
+#[derive(Encodeable)]
+pub struct Good {
+    #[encode(config = minnow::FloatModel::new(-1.0..=1.0, 1).unwrap())]
+    x: f64,
+}
+
+fn main() {}

--- a/minnow-derive/tests/ui/pass/generic_struct.rs
+++ b/minnow-derive/tests/ui/pass/generic_struct.rs
@@ -1,0 +1,10 @@
+// A generic struct: the derive adds the `EncodeableCustom`/`Config: Default`
+// bounds itself, so the user doesn't have to spell them out.
+use minnow_derive::Encodeable;
+
+#[derive(Encodeable)]
+pub struct Good<T> {
+    inner: T,
+}
+
+fn main() {}

--- a/minnow-derive/tests/ui/pass/struct_and_multi_field_variants.rs
+++ b/minnow-derive/tests/ui/pass/struct_and_multi_field_variants.rs
@@ -1,0 +1,19 @@
+// Struct-style and multi-field tuple enum variants, with per-field
+// attributes.
+use minnow_derive::Encodeable;
+
+#[derive(Encodeable)]
+pub enum Good {
+    Unit,
+    Tuple(
+        #[encode(float(min = 0.0, max = 1.0, precision = 0))] f64,
+        bool,
+    ),
+    Struct {
+        #[encode(float(min = 0.0, max = 1.0, precision = 0))]
+        x: f64,
+        y: bool,
+    },
+}
+
+fn main() {}

--- a/minnow-derive/tests/ui/pass/unit_struct.rs
+++ b/minnow-derive/tests/ui/pass/unit_struct.rs
@@ -1,0 +1,7 @@
+// A unit struct: weight 1, zero bits, no-op encode/decode.
+use minnow_derive::Encodeable;
+
+#[derive(Encodeable)]
+pub struct Good;
+
+fn main() {}

--- a/src/encodeable.rs
+++ b/src/encodeable.rs
@@ -1,9 +1,7 @@
-use std::io;
-
 use bitstream_io::{BigEndian, BitRead, BitReader, BitWrite, BitWriter};
 
 use crate::{
-    DecodeError, PRECISION, SizeReport,
+    DecodeError, EncodeError, PRECISION, SizeReport,
     encodeable_custom::EncodeableCustom,
     visitor::{DecodeVisitor, EncodeVisitor},
 };
@@ -19,9 +17,9 @@ pub trait Encodeable {
     ///
     /// # Errors
     ///
-    /// This method can fail if the [`EncodeVisitor`]'s underlying writer cannot
-    /// be written to.
-    fn encode<W>(&self, visitor: &mut EncodeVisitor<W>) -> io::Result<()>
+    /// Returns [`EncodeError`] if a value lies outside its model's configured
+    /// domain, or if the underlying writer cannot be written to.
+    fn encode<W>(&self, visitor: &mut EncodeVisitor<W>) -> Result<(), EncodeError>
     where
         W: BitWrite;
 
@@ -58,27 +56,20 @@ pub trait Encodeable {
 
     /// Encode the struct into a [`Vec<u8>`].
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// This method is infallible in practice: writing to a `Vec<u8>` cannot
-    /// produce an I/O error. It will only panic if that invariant is somehow
-    /// violated.
-    fn encode_bytes(&self) -> Vec<u8> {
+    /// Returns [`EncodeError`] if a value lies outside its model's configured
+    /// domain. Writing to the `Vec<u8>` itself cannot fail.
+    fn encode_bytes(&self) -> Result<Vec<u8>, EncodeError> {
         let mut bit_writer = BitWriter::endian(Vec::new(), BigEndian);
         let mut encoder = EncodeVisitor::new(PRECISION, &mut bit_writer);
 
-        // Writing to a `Vec<u8>` is infallible, so these operations cannot fail.
-        self.encode(&mut encoder)
-            .expect("writing to Vec<u8> is infallible");
-        encoder.flush().expect("writing to Vec<u8> is infallible");
-        bit_writer
-            .byte_align()
-            .expect("writing to Vec<u8> is infallible");
-        bit_writer
-            .flush()
-            .expect("writing to Vec<u8> is infallible");
+        self.encode(&mut encoder)?;
+        encoder.flush()?;
+        bit_writer.byte_align()?;
+        bit_writer.flush()?;
 
-        bit_writer.into_writer()
+        Ok(bit_writer.into_writer())
     }
 
     /// Decode the struct using the provided [`DecodeVisitor`].
@@ -128,7 +119,7 @@ where
     T: EncodeableCustom<Config = C>,
     C: Default,
 {
-    fn encode<W>(&self, visitor: &mut EncodeVisitor<W>) -> io::Result<()>
+    fn encode<W>(&self, visitor: &mut EncodeVisitor<W>) -> Result<(), EncodeError>
     where
         W: BitWrite,
     {

--- a/src/encodeable_custom.rs
+++ b/src/encodeable_custom.rs
@@ -1,9 +1,7 @@
-use std::io;
-
 use bitstream_io::{BigEndian, BitRead, BitReader, BitWrite, BitWriter};
 
 use crate::{
-    DecodeError, PRECISION, SizeReport, Weight,
+    DecodeError, EncodeError, PRECISION, SizeReport, Weight,
     visitor::{DecodeVisitor, EncodeVisitor},
 };
 
@@ -70,40 +68,33 @@ pub trait EncodeableCustom {
     ///
     /// # Errors
     ///
-    /// This method can fail if the [`EncodeVisitor`]'s underlying writer cannot
-    /// be written to.
+    /// Returns [`EncodeError`] if a value lies outside its model's configured
+    /// domain (see [`EncodeError::OutOfRange`] and the saturation opt-in
+    /// documented there), or if the underlying writer cannot be written to.
     fn encode_with_config<W>(
         &self,
         visitor: &mut EncodeVisitor<W>,
         config: Self::Config,
-    ) -> io::Result<()>
+    ) -> Result<(), EncodeError>
     where
         W: BitWrite;
 
     /// Encode the struct into a [`Vec<u8>`] using the provided configuration.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// This method is infallible in practice: writing to a `Vec<u8>` cannot
-    /// produce an I/O error. It will only panic if that invariant is somehow
-    /// violated.
-    fn encode_bytes_with_config(&self, config: Self::Config) -> Vec<u8> {
+    /// Returns [`EncodeError`] if a value lies outside its model's configured
+    /// domain. Writing to the `Vec<u8>` itself cannot fail.
+    fn encode_bytes_with_config(&self, config: Self::Config) -> Result<Vec<u8>, EncodeError> {
         let mut bit_writer = BitWriter::endian(Vec::new(), BigEndian);
         let mut encoder = EncodeVisitor::new(PRECISION, &mut bit_writer);
 
-        self.encode_with_config(&mut encoder, config)
-            .expect("can't get io errors when writing to Vec<u8>");
-        encoder
-            .flush()
-            .expect("can't get io errors when writing to Vec<u8>");
-        bit_writer
-            .byte_align()
-            .expect("can't get io errors when writing to Vec<u8>");
-        bit_writer
-            .flush()
-            .expect("can't get io errors when writing to Vec<u8>");
+        self.encode_with_config(&mut encoder, config)?;
+        encoder.flush()?;
+        bit_writer.byte_align()?;
+        bit_writer.flush()?;
 
-        bit_writer.into_writer()
+        Ok(bit_writer.into_writer())
     }
 
     /// Decode the struct using the provided configuration and
@@ -148,7 +139,10 @@ pub trait EncodeableCustom {
         // weighting the two ends coincide, pinning the length exactly and
         // catching truncation; manual `#[encode(weight)]` overrides widen the
         // window but it still never rejects a genuinely valid encoding.
-        let expected = Self::report(&config).total_bytes();
+        // Computed from the scalar bit bounds directly — building the full
+        // `SizeReport` tree here would be wasted work on every decode.
+        let expected =
+            crate::report::bytes_for(Self::worst_case_bits(&config) + crate::TERMINATION_BITS);
         let lower = crate::report::bytes_for(Self::best_case_bits(&config));
         let actual = bytes.len();
         if actual < lower || actual > expected {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-//! Error types produced while decoding.
+//! Error types produced while encoding and decoding.
 
 /// An error that can occur while decoding a value from a stream of bits.
 ///
@@ -47,4 +47,67 @@ pub enum DecodeError {
         /// The number of bytes actually supplied.
         actual: usize,
     },
+
+    /// The decoded byte sequence for a [`String`] field was not valid UTF-8.
+    ///
+    /// [`String`]'s wire format (see [`crate::StringModel`]) is a bounded
+    /// sequence of raw bytes; any byte value round-trips, but not every byte
+    /// sequence is valid UTF-8. A corrupt or malicious stream can decode to a
+    /// byte sequence that isn't, which this variant reports rather than
+    /// panicking on the `unwrap` a naive implementation might reach for.
+    #[error("decoded bytes are not valid UTF-8: {0}")]
+    InvalidUtf8(#[from] std::string::FromUtf8Error),
+}
+
+/// An error that can occur while encoding a value.
+///
+/// Encoding is fallible **by design**: a value outside a model's configured
+/// domain is a broken caller assumption, and silently coercing it would
+/// deliver plausible-but-wrong data to the receiver. In-range quantisation
+/// (rounding to the model's declared precision) is not an error — its loss is
+/// bounded by the precision the schema explicitly declares — whereas
+/// out-of-range loss is unbounded, so it is surfaced here instead. Models
+/// with a meaningful nearest-value projection offer clamping as an explicit
+/// opt-in ([`FloatModel::clamping`](crate::FloatModel::clamping),
+/// [`IntModel::clamping`](crate::IntModel::clamping)).
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum EncodeError {
+    /// The value lies outside the model's configured `min..=max` range, and
+    /// the model has not opted into clamping.
+    #[error("value {value} is outside the configured range {min}..={max}")]
+    OutOfRange {
+        /// The offending value.
+        value: String,
+        /// The model's lower bound.
+        min: String,
+        /// The model's upper bound.
+        max: String,
+    },
+
+    /// The value is NaN or infinite, which no bounded model can represent.
+    ///
+    /// Clamping does not apply: there is no nearest representable value to
+    /// a NaN, so this is an error even in saturating mode.
+    #[error("value {value} is not finite")]
+    NonFinite {
+        /// The offending value.
+        value: String,
+    },
+
+    /// A sequence has more elements than the model's configured `max_len`.
+    ///
+    /// Sequences have no clamping mode: truncation would silently drop
+    /// elements, which is not a nearest-value projection.
+    #[error("sequence of {len} elements exceeds the configured maximum length ({max_len})")]
+    TooLong {
+        /// The number of elements in the sequence.
+        len: usize,
+        /// The model's maximum length.
+        max_len: u32,
+    },
+
+    /// The underlying writer could not be written to.
+    #[error("i/o error while encoding: {0}")]
+    Io(#[from] std::io::Error),
 }

--- a/src/float.rs
+++ b/src/float.rs
@@ -6,37 +6,7 @@ use std::{
 use arithmetic_coding::one_shot;
 use num_traits::Float;
 
-use crate::MAX_DENOMINATOR;
-
-/// An error returned when a model cannot be constructed because its parameters
-/// violate the arithmetic coder's precision invariant (see
-/// [`MAX_DENOMINATOR`](crate::MAX_DENOMINATOR)) or are otherwise invalid.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-#[non_exhaustive]
-pub enum ModelError {
-    /// One or both of the supplied bounds was `NaN` or infinite.
-    #[error("model bounds must be finite (neither NaN nor infinite)")]
-    NonFiniteBounds,
-
-    /// The lower bound was greater than the upper bound.
-    #[error("model lower bound must not exceed the upper bound")]
-    InvertedBounds,
-
-    /// The resulting denominator exceeds
-    /// [`MAX_DENOMINATOR`](crate::MAX_DENOMINATOR).
-    #[error(
-        "model denominator ({denominator}) exceeds the maximum ({max}) permitted at precision \
-         {precision}; narrow the range or reduce the precision"
-    )]
-    DenominatorTooLarge {
-        /// The denominator that was requested.
-        denominator: u128,
-        /// The maximum permissible denominator.
-        max: u128,
-        /// The arithmetic coder precision in bits.
-        precision: u32,
-    },
-}
+use crate::{EncodeError, MAX_DENOMINATOR, ModelError};
 
 /// A [`Model`](arithmetic_coding::Model) which (lossily) encodes and decodes
 /// floating point values.
@@ -49,6 +19,7 @@ where
     min: F,
     max: F,
     precision: i8,
+    clamping: bool,
 }
 
 impl<F> Default for FloatModel<F>
@@ -68,7 +39,8 @@ where
 {
     /// Create a new [`FloatModel`] with the given range and precision.
     ///
-    /// Values outside this range will be coerced to the nearest bound. The
+    /// Encoding a value outside this range is an [`EncodeError::OutOfRange`]
+    /// unless [clamping](FloatModel::clamping) mode is enabled. The
     /// `precision` is the number of decimal digits retained (it may be
     /// negative to quantise more coarsely than integers).
     ///
@@ -92,6 +64,7 @@ where
             min,
             max,
             precision,
+            clamping: false,
         };
 
         // The denominator is the number of distinguishable values in the range.
@@ -125,13 +98,61 @@ where
         self.scale(self.max) + 1
     }
 
+    /// Enable clamping mode: encoding a value outside `min..=max` clamps it
+    /// to the nearest bound instead of returning
+    /// [`EncodeError::OutOfRange`].
+    ///
+    /// In-range quantisation (rounding to the declared precision) always
+    /// happens and is not affected — its loss is bounded by half a
+    /// quantisation step, which the schema explicitly declares. Saturation
+    /// opts into *unbounded* loss at the boundaries, which is the right
+    /// policy for naturally saturating sources (sensor channels) and the
+    /// wrong one for most everything else — hence opt-in. NaN and infinite
+    /// values are an [`EncodeError::NonFinite`] in every mode: no nearest
+    /// representable value exists.
+    #[must_use]
+    pub const fn clamping(mut self) -> Self {
+        self.clamping = true;
+        self
+    }
+
+    /// Validate `value` against this model's domain, returning the value that
+    /// will actually be encoded.
+    ///
+    /// # Errors
+    ///
+    /// [`EncodeError::NonFinite`] for NaN/infinite values;
+    /// [`EncodeError::OutOfRange`] for values outside `min..=max` unless
+    /// [clamping](FloatModel::clamping) mode is enabled.
+    pub(crate) fn admit(&self, value: F) -> Result<F, EncodeError> {
+        if !value.is_finite() {
+            return Err(EncodeError::NonFinite {
+                value: format!("{value:?}"),
+            });
+        }
+        if value < self.min || value > self.max {
+            if self.clamping {
+                return Ok(num_traits::clamp(value, self.min, self.max));
+            }
+            return Err(EncodeError::OutOfRange {
+                value: format!("{value:?}"),
+                min: format!("{:?}", self.min),
+                max: format!("{:?}", self.max),
+            });
+        }
+        Ok(value)
+    }
+
     fn multiplier(&self) -> F {
         F::from(10_u32).unwrap().powi(self.precision.into())
     }
 
     fn scale(&self, value: F) -> u128 {
-        let input = num_traits::clamp(value, self.min, self.max);
-        let float = ((input - self.min) * self.multiplier()).round();
+        debug_assert!(
+            value >= self.min && value <= self.max,
+            "scale is only called with admitted (in-range) values"
+        );
+        let float = ((value - self.min) * self.multiplier()).round();
         num_traits::ToPrimitive::to_u128(&float).unwrap()
     }
 
@@ -170,8 +191,8 @@ mod tests {
     use arithmetic_coding::fixed_length::Model;
     use test_case::test_case;
 
-    use super::{FloatModel, ModelError};
-    use crate::MAX_DENOMINATOR;
+    use super::FloatModel;
+    use crate::{EncodeError, MAX_DENOMINATOR, ModelError};
 
     #[test]
     fn denominator() {
@@ -179,6 +200,7 @@ mod tests {
             min: 0.0,
             max: 1.0,
             precision: 1,
+            clamping: false,
         };
 
         assert_eq!(model.denominator(), 11);
@@ -187,12 +209,12 @@ mod tests {
     #[test_case(0.0 => 0)]
     #[test_case(0.5 => 5)]
     #[test_case(1.0 => 10)]
-    #[test_case(1.1 => 10)]
     fn scale(input: f64) -> u128 {
         let model = FloatModel {
             min: 0.0,
             max: 1.0,
             precision: 1,
+            clamping: false,
         };
 
         model.scale(input)
@@ -206,6 +228,7 @@ mod tests {
             min: 0.0,
             max: 1.0,
             precision: 1,
+            clamping: false,
         };
 
         model.probability(&input).unwrap()
@@ -221,6 +244,7 @@ mod tests {
             min: 0.0,
             max: 1.0,
             precision: 1,
+            clamping: false,
         };
 
         model.symbol(value)
@@ -264,5 +288,29 @@ mod tests {
         // A billion distinguishable values is far below MAX_DENOMINATOR (2^62).
         const _: () = assert!(MAX_DENOMINATOR > 1_000_000_000);
         assert!(FloatModel::new(0.0..=1_000_000_000.0, 0).is_ok());
+    }
+
+    /// Out-of-range values are an error by default, clamp only under the
+    /// explicit clamping opt-in, and NaN is an error in every mode.
+    #[test]
+    fn admit_semantics() {
+        let strict = FloatModel::new(0.0..=1.0, 1).unwrap();
+        assert!(matches!(
+            strict.admit(1.1),
+            Err(EncodeError::OutOfRange { .. })
+        ));
+        assert!(matches!(
+            strict.admit(f64::NAN),
+            Err(EncodeError::NonFinite { .. })
+        ));
+
+        let clamping = FloatModel::new(0.0..=1.0, 1).unwrap().clamping();
+        assert!((clamping.admit(1.1_f64).unwrap() - 1.0).abs() < f64::EPSILON);
+        assert!(clamping.admit(-5.0_f64).unwrap().abs() < f64::EPSILON);
+        // No nearest representable value exists for NaN, even when clamping.
+        assert!(matches!(
+            clamping.admit(f64::NAN),
+            Err(EncodeError::NonFinite { .. })
+        ));
     }
 }

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -1,10 +1,8 @@
-use std::io;
-
 use bitstream_io::{BitRead, BitWrite};
 
 use self::{one_shot::OneShot, weighted::WeightedModel};
 use crate::{
-    DecodeError, DecodeVisitor, EncodeVisitor, SizeReport, Weight,
+    DecodeError, DecodeVisitor, EncodeError, EncodeVisitor, SizeReport, Weight,
     encodeable_custom::EncodeableCustom, float::FloatModel,
 };
 
@@ -55,19 +53,19 @@ where
         &self,
         visitor: &mut EncodeVisitor<W>,
         config: T::Config,
-    ) -> io::Result<()>
+    ) -> Result<(), EncodeError>
     where
         W: BitWrite,
     {
         // Every value of `Option<T>` costs exactly `log₂(1 + W(T))` bits under
         // the shared weighted discriminant.
         let model = option_discriminant::<T>(&config);
-        match self {
-            Some(x) => {
-                visitor.encode_one(model, &1_u32)?;
-                x.encode_with_config(visitor, config)
-            }
-            None => visitor.encode_one(model, &0_u32),
+        if let Some(x) = self {
+            visitor.encode_one(model, &1_u32)?;
+            x.encode_with_config(visitor, config)
+        } else {
+            visitor.encode_one(model, &0_u32)?;
+            Ok(())
         }
     }
 
@@ -92,6 +90,39 @@ where
     }
 }
 
+impl EncodeableCustom for () {
+    type Config = ();
+
+    fn weight(_config: &Self::Config) -> Weight {
+        // A single encodable value: the unit itself.
+        Weight::ONE
+    }
+
+    fn encode_with_config<W>(
+        &self,
+        _visitor: &mut EncodeVisitor<W>,
+        _config: (),
+    ) -> Result<(), EncodeError>
+    where
+        W: BitWrite,
+    {
+        // Nothing to encode: `weight() == Weight::ONE`, so `()` costs zero
+        // bits on the wire.
+        Ok(())
+    }
+
+    fn decode_with_config<R>(
+        _visitor: &mut DecodeVisitor<R>,
+        _config: (),
+    ) -> Result<Self, DecodeError>
+    where
+        R: BitRead,
+        Self: Sized,
+    {
+        Ok(())
+    }
+}
+
 impl EncodeableCustom for f64 {
     type Config = FloatModel<f64>;
 
@@ -103,11 +134,13 @@ impl EncodeableCustom for f64 {
         &self,
         visitor: &mut EncodeVisitor<W>,
         config: Self::Config,
-    ) -> io::Result<()>
+    ) -> Result<(), EncodeError>
     where
         W: BitWrite,
     {
-        visitor.encode_one(config, self)
+        let value = config.admit(*self)?;
+        visitor.encode_one(config, &value)?;
+        Ok(())
     }
 
     fn decode_with_config<R>(
@@ -129,13 +162,18 @@ impl EncodeableCustom for bool {
         Weight::new(2)
     }
 
-    fn encode_with_config<W>(&self, visitor: &mut EncodeVisitor<W>, _config: ()) -> io::Result<()>
+    fn encode_with_config<W>(
+        &self,
+        visitor: &mut EncodeVisitor<W>,
+        _config: (),
+    ) -> Result<(), EncodeError>
     where
         W: BitWrite,
     {
         let model = OneShot::<2>;
         let value = u32::from(*self);
-        visitor.encode_one(model, &value)
+        visitor.encode_one(model, &value)?;
+        Ok(())
     }
 
     fn decode_with_config<R>(
@@ -186,20 +224,23 @@ where
     }
 
     fn report(config: &Self::Config) -> SizeReport {
-        // Every element has the same config, so compute the (possibly deep)
-        // element report once and clone it per index.
-        let element = T::report(config);
-        let children = (0..N)
-            .map(|i| element.clone().with_name(i.to_string()))
-            .collect();
-        SizeReport::product(children)
+        // A compact tree — one element *template* rather than one node per
+        // element (`N` can be large, and this report is built on every
+        // `decode_bytes` call). The node's bit total is computed
+        // arithmetically instead of summed from children, so it stays exact.
+        let element = T::report(config).with_name(format!("element (× {N})"));
+        SizeReport {
+            name: None,
+            bits: Self::worst_case_bits(config),
+            children: vec![element],
+        }
     }
 
     fn encode_with_config<W>(
         &self,
         visitor: &mut EncodeVisitor<W>,
         config: T::Config,
-    ) -> io::Result<()>
+    ) -> Result<(), EncodeError>
     where
         W: BitWrite,
     {
@@ -255,6 +296,7 @@ mod tests {
     #[test_case(&Option::Some(false))]
     #[test_case(&true)]
     #[test_case(&false)]
+    #[test_case(&())]
     fn round_trip<T>(input: &T)
     where
         T: Encodeable + std::fmt::Debug + PartialEq,
@@ -283,6 +325,7 @@ mod tests {
     #[test_case(&Option::Some(false), ())]
     #[test_case(&true, ())]
     #[test_case(&false, ())]
+    #[test_case(&(), ())]
     #[test_case(&450.0_f64, FloatModel::new(-10000.0..=10000.0, 1).unwrap())]
     #[test_case(&550.0_f64, FloatModel::new(-10000.0..=10000.0, 1).unwrap())]
     #[test_case(&-100.0_f64, FloatModel::new(-5000.0..=0.0, 0).unwrap())]
@@ -311,5 +354,16 @@ mod tests {
         let output = T::decode_with_config(&mut decoder, config).unwrap();
 
         assert_eq!(input, &output);
+    }
+
+    #[test]
+    #[allow(clippy::float_cmp)]
+    fn unit_type_costs_zero_bits() {
+        assert_eq!(<() as EncodeableCustom>::weight(&()), crate::Weight::ONE);
+        assert_eq!(<() as EncodeableCustom>::worst_case_bits(&()), 0.0);
+        // Zero payload bits still incurs coder-termination overhead, rounded
+        // up to a whole byte.
+        assert_eq!(().encode_bytes().unwrap().len(), 1);
+        assert_eq!(<() as Encodeable>::size_report().total_bytes(), 1);
     }
 }

--- a/src/int.rs
+++ b/src/int.rs
@@ -1,0 +1,341 @@
+//! A model for bounded integers (issue #3's sibling: the numeric leaf that
+//! [`crate::StringModel`]/[`crate::SeqModel`] build on for byte alphabets).
+//!
+//! [`IntModel<T>`] encodes a value of an integer type `T` uniformly over an
+//! inclusive `min..=max` range: weight `max − min + 1`, one symbol per value.
+//! It is implemented for every primitive integer type from `u8`/`i8` up to
+//! `u64`/`i64`.
+
+use std::{
+    convert::Infallible,
+    ops::{Range, RangeInclusive},
+};
+
+use arithmetic_coding::one_shot;
+use num_traits::PrimInt;
+
+use crate::{
+    DecodeError, DecodeVisitor, EncodeError, EncodeVisitor, EncodeableCustom, MAX_DENOMINATOR,
+    ModelError, PRECISION, Weight,
+};
+
+/// Convert a supported integer type to `i128`.
+///
+/// Every type this module supports (`u8..=u64`, `i8..=i64`) fits losslessly
+/// in `i128`, so this never fails in practice.
+fn to_i128<T: PrimInt>(value: T) -> i128 {
+    num_traits::ToPrimitive::to_i128(&value)
+        .expect("every type IntModel supports fits losslessly in i128")
+}
+
+/// Convert an `i128` back to a supported integer type.
+///
+/// Callers must ensure `value` is within `T`'s range; [`IntModel`] only ever
+/// calls this with offsets bounded by its own `min..=max`, so the conversion
+/// always succeeds.
+fn from_i128<T: PrimInt>(value: i128) -> T {
+    <T as num_traits::NumCast>::from(value)
+        .expect("value is within the configured range, which is within T's range")
+}
+
+/// The number of distinct values in `min..=max`, as a `u128`.
+fn width<T: PrimInt>(min: T, max: T) -> u128 {
+    let diff = to_i128(max) - to_i128(min);
+    // `max >= min` is checked by every caller before this runs, so `diff` is
+    // never negative.
+    u128::try_from(diff).expect("max >= min, so the difference is non-negative")
+}
+
+/// A [`Model`](arithmetic_coding::one_shot::Model) which encodes and decodes
+/// a bounded integer, uniform over `min..=max`.
+///
+/// The weight (see [`crate::Weight`]) of an `IntModel` is `max − min + 1`:
+/// every value in the range is equally likely and costs the same fractional
+/// number of bits.
+#[derive(Clone, Copy, Debug)]
+pub struct IntModel<T> {
+    min: T,
+    max: T,
+    clamping: bool,
+}
+
+impl<T> IntModel<T>
+where
+    T: PrimInt + std::fmt::Debug,
+{
+    /// Create a new [`IntModel`] over the given inclusive range.
+    ///
+    /// Encoding a value outside this range is an [`EncodeError::OutOfRange`]
+    /// unless [clamping](IntModel::clamping) mode is enabled.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelError::InvertedBounds`] if `min > max`, or
+    /// [`ModelError::DenominatorTooLarge`] if the number of distinguishable
+    /// values in the range (`max − min + 1`) would exceed
+    /// [`MAX_DENOMINATOR`](crate::MAX_DENOMINATOR).
+    pub fn new(range: RangeInclusive<T>) -> Result<Self, ModelError> {
+        let min = *range.start();
+        let max = *range.end();
+
+        if min > max {
+            return Err(ModelError::InvertedBounds);
+        }
+
+        let width = width(min, max);
+        // `denominator = width + 1`; reject before the `+ 1` can overflow or
+        // exceed the bound (mirrors `FloatModel::new`).
+        if width >= MAX_DENOMINATOR {
+            return Err(ModelError::DenominatorTooLarge {
+                denominator: width.saturating_add(1),
+                max: MAX_DENOMINATOR,
+                precision: PRECISION,
+            });
+        }
+
+        Ok(Self {
+            min,
+            max,
+            clamping: false,
+        })
+    }
+
+    /// Enable clamping mode: encoding a value outside `min..=max` clamps it
+    /// to the nearest bound instead of returning
+    /// [`EncodeError::OutOfRange`].
+    ///
+    /// Clamping is the right policy for naturally saturating sources
+    /// (sensor channels) and the wrong one for most everything else — hence
+    /// opt-in; see [`EncodeError`] for the reasoning.
+    #[must_use]
+    pub const fn clamping(mut self) -> Self {
+        self.clamping = true;
+        self
+    }
+
+    /// Validate `value` against this model's domain, returning the value that
+    /// will actually be encoded.
+    ///
+    /// # Errors
+    ///
+    /// [`EncodeError::OutOfRange`] for values outside `min..=max`, unless
+    /// [clamping](IntModel::clamping) mode is enabled.
+    fn admit(&self, value: T) -> Result<T, EncodeError> {
+        if value < self.min || value > self.max {
+            if self.clamping {
+                return Ok(num_traits::clamp(value, self.min, self.max));
+            }
+            return Err(EncodeError::OutOfRange {
+                value: format!("{value:?}"),
+                min: format!("{:?}", self.min),
+                max: format!("{:?}", self.max),
+            });
+        }
+        Ok(value)
+    }
+
+    /// The number of distinct values this model can encode — its
+    /// [`Weight`](crate::Weight): `max − min + 1`.
+    #[must_use]
+    pub fn denominator(&self) -> u128 {
+        width(self.min, self.max) + 1
+    }
+
+    /// The offset of `value` from `min`, as a `u128` in `0..denominator()`.
+    fn offset(&self, value: T) -> u128 {
+        debug_assert!(
+            value >= self.min && value <= self.max,
+            "offset is only called with admitted (in-range) values"
+        );
+        let diff = to_i128(value) - to_i128(self.min);
+        u128::try_from(diff).expect("admitted value is at least min")
+    }
+
+    /// The inverse of [`IntModel::offset`].
+    fn unscale(&self, offset: u128) -> T {
+        let offset = i128::try_from(offset).expect("offset is bounded by the denominator");
+        from_i128(to_i128(self.min) + offset)
+    }
+}
+
+impl<T> one_shot::Model for IntModel<T>
+where
+    T: PrimInt + std::fmt::Debug,
+{
+    type B = u128;
+    type Symbol = T;
+    type ValueError = Infallible;
+
+    fn probability(&self, symbol: &Self::Symbol) -> Result<Range<Self::B>, Self::ValueError> {
+        let offset = self.offset(*symbol);
+        #[allow(clippy::range_plus_one)]
+        Ok(offset..offset + 1)
+    }
+
+    fn max_denominator(&self) -> Self::B {
+        self.denominator()
+    }
+
+    fn symbol(&self, value: Self::B) -> Self::Symbol {
+        self.unscale(value)
+    }
+}
+
+/// Implement [`EncodeableCustom`] for a primitive integer type `$t`, whose
+/// config is `IntModel<$t>`.
+///
+/// The `@default` variant additionally gives the type a [`Default`]
+/// `IntModel` spanning its entire native range (`$t::MIN..=$t::MAX`), which
+/// is only safe for types whose full range fits within
+/// [`MAX_DENOMINATOR`](crate::MAX_DENOMINATOR) — `u64`/`i64` do not (their
+/// full-range denominator, `2^64`, exceeds the ~`2^62` bound), so those two
+/// types require an explicit [`IntModel::new`] range and have no `Default`.
+macro_rules! impl_int_leaf {
+    (@default $t:ty) => {
+        impl Default for IntModel<$t> {
+            fn default() -> Self {
+                Self::new(<$t>::MIN..=<$t>::MAX)
+                    .expect("the full range of this type fits within MAX_DENOMINATOR")
+            }
+        }
+        impl_int_leaf!(@no_default $t);
+    };
+    (@no_default $t:ty) => {
+        impl EncodeableCustom for $t {
+            type Config = IntModel<$t>;
+
+            fn weight(config: &Self::Config) -> Weight {
+                Weight::new(config.denominator())
+            }
+
+            fn encode_with_config<W>(
+                &self,
+                visitor: &mut EncodeVisitor<W>,
+                config: Self::Config,
+            ) -> Result<(), EncodeError>
+            where
+                W: bitstream_io::BitWrite,
+            {
+                let value = config.admit(*self)?;
+                visitor.encode_one(config, &value)?;
+                Ok(())
+            }
+
+            fn decode_with_config<R>(
+                visitor: &mut DecodeVisitor<R>,
+                config: Self::Config,
+            ) -> Result<Self, DecodeError>
+            where
+                R: bitstream_io::BitRead,
+                Self: Sized,
+            {
+                visitor.decode_one(config)
+            }
+        }
+    };
+}
+
+impl_int_leaf!(@default u8);
+impl_int_leaf!(@default u16);
+impl_int_leaf!(@default u32);
+impl_int_leaf!(@default i8);
+impl_int_leaf!(@default i16);
+impl_int_leaf!(@default i32);
+// `u64`/`i64` have no `Default` `IntModel`: their full native range's
+// denominator (`2^64`) exceeds `MAX_DENOMINATOR` (`~2^62`), so callers must
+// supply an explicit bounded range.
+impl_int_leaf!(@no_default u64);
+impl_int_leaf!(@no_default i64);
+
+#[cfg(test)]
+mod tests {
+    use arithmetic_coding::one_shot::Model;
+    use test_case::test_case;
+
+    use super::IntModel;
+    use crate::ModelError;
+
+    #[test]
+    fn denominator() {
+        let model = IntModel::new(-5_i32..=5).unwrap();
+        assert_eq!(model.denominator(), 11);
+    }
+
+    #[test_case(0 => 0..1)]
+    #[test_case(5 => 5..6)]
+    #[test_case(-5 => -5..-4; "negative")]
+    fn probability(input: i32) -> std::ops::Range<i32> {
+        let model = IntModel::new(-5_i32..=5).unwrap();
+        // Translate the returned `u128` interval back to an `i32` range for a
+        // readable assertion.
+        let range = model.probability(&input).unwrap();
+        #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+        let start = range.start as i32 - 5;
+        #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+        let end = range.end as i32 - 5;
+        start..end
+    }
+
+    #[test]
+    fn round_trips_symbol() {
+        let model = IntModel::new(-1000_i32..=1000).unwrap();
+        for value in [-1000, -1, 0, 1, 1000] {
+            let range = model.probability(&value).unwrap();
+            assert_eq!(model.symbol(range.start), value);
+        }
+    }
+
+    #[test]
+    fn rejects_inverted_bounds() {
+        let min = 5_i32;
+        let max = -5_i32;
+        assert_eq!(
+            IntModel::new(min..=max).unwrap_err(),
+            ModelError::InvertedBounds
+        );
+    }
+
+    #[test]
+    fn rejects_oversized_denominator() {
+        let err = IntModel::new(0_i64..=i64::MAX).unwrap_err();
+        assert!(matches!(err, ModelError::DenominatorTooLarge { .. }));
+    }
+
+    #[test]
+    fn accepts_full_u64_minus_epsilon() {
+        // The largest range whose weight (width + 1) is still <=
+        // MAX_DENOMINATOR.
+        let max_denominator = u64::try_from(crate::MAX_DENOMINATOR).unwrap();
+        assert!(IntModel::new(0_u64..=(max_denominator - 1)).is_ok());
+        assert!(IntModel::new(0_u64..=max_denominator).is_err());
+    }
+
+    #[test]
+    fn u8_default_spans_full_range() {
+        let model = IntModel::<u8>::default();
+        assert_eq!(model.denominator(), 256);
+    }
+
+    #[test]
+    fn i8_default_spans_full_range() {
+        let model = IntModel::<i8>::default();
+        assert_eq!(model.denominator(), 256);
+    }
+
+    /// Out-of-range values are an error by default and clamp only under the
+    /// explicit clamping opt-in.
+    #[test]
+    fn admit_semantics() {
+        let strict = IntModel::new(0_u8..=10).unwrap();
+        assert_eq!(strict.admit(7).unwrap(), 7);
+        assert!(matches!(
+            strict.admit(11),
+            Err(crate::EncodeError::OutOfRange { .. })
+        ));
+
+        let clamping = IntModel::new(-5_i32..=5).unwrap().clamping();
+        assert_eq!(clamping.admit(-100).unwrap(), -5);
+        assert_eq!(clamping.admit(100).unwrap(), 5);
+        assert_eq!(clamping.admit(3).unwrap(), 3);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,17 +19,25 @@ mod encodeable_custom;
 mod error;
 mod float;
 mod impls;
+mod int;
+mod model_error;
 mod report;
+mod seq;
+mod string;
 mod visitor;
 mod weight;
 
 pub use encodeable::Encodeable;
 pub use encodeable_custom::EncodeableCustom;
-pub use error::DecodeError;
-pub use float::{FloatModel, ModelError};
+pub use error::{DecodeError, EncodeError};
+pub use float::FloatModel;
 pub use impls::{one_shot::OneShot, weighted::WeightedModel};
+pub use int::IntModel;
 pub use minnow_derive::Encodeable;
+pub use model_error::ModelError;
 pub use report::{SizeReport, TERMINATION_BITS};
+pub use seq::SeqModel;
+pub use string::StringModel;
 pub use visitor::{DecodeVisitor, EncodeVisitor};
 pub use weight::Weight;
 

--- a/src/model_error.rs
+++ b/src/model_error.rs
@@ -1,0 +1,38 @@
+//! The shared error type for fallible leaf-model constructors.
+
+/// An error returned when a model cannot be constructed because its
+/// parameters violate the arithmetic coder's precision invariant (see
+/// [`MAX_DENOMINATOR`](crate::MAX_DENOMINATOR)) or are otherwise invalid.
+///
+/// Every leaf model with a fallible constructor
+/// ([`FloatModel::new`](crate::FloatModel::new),
+/// [`IntModel::new`](crate::IntModel::new),
+/// [`StringModel::new`](crate::StringModel::new)) shares this one error type,
+/// so callers only need to handle a single error shape regardless of which
+/// model they are building.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum ModelError {
+    /// One or both of the supplied bounds was `NaN` or infinite.
+    #[error("model bounds must be finite (neither NaN nor infinite)")]
+    NonFiniteBounds,
+
+    /// The lower bound was greater than the upper bound.
+    #[error("model lower bound must not exceed the upper bound")]
+    InvertedBounds,
+
+    /// The resulting denominator exceeds
+    /// [`MAX_DENOMINATOR`](crate::MAX_DENOMINATOR).
+    #[error(
+        "model denominator ({denominator}) exceeds the maximum ({max}) permitted at precision \
+         {precision}; narrow the range or reduce the precision"
+    )]
+    DenominatorTooLarge {
+        /// The denominator that was requested.
+        denominator: u128,
+        /// The maximum permissible denominator.
+        max: u128,
+        /// The arithmetic coder precision in bits.
+        precision: u32,
+    },
+}

--- a/src/seq.rs
+++ b/src/seq.rs
@@ -1,0 +1,345 @@
+//! A length-prefixed model for bounded sequences (`Vec<T>`, issue #5), and the
+//! byte-sequence machinery [`crate::StringModel`] builds on.
+//!
+//! # Wire format
+//!
+//! A sequence of at most `max_len` elements is encoded as:
+//!
+//! 1. a **uniform** length symbol over `0..=max_len` (`max_len + 1` equally
+//!    likely values), costing exactly `log₂(max_len + 1)` bits;
+//! 2. that many elements, each encoded with the shared `elem` config.
+//!
+//! # The math
+//!
+//! Per the cardinality semiring (see [`crate::Weight`]), a bounded sequence is
+//! a sum-of-products over its possible lengths:
+//!
+//! ```text
+//! W(Vec<T>) = Σ_{k=0}^{L} W(T)^k        (saturating)
+//! ```
+//!
+//! and the bit-accounting methods follow directly from the uniform length
+//! prefix:
+//!
+//! ```text
+//! worst_case_bits = log₂(L + 1) + L · worst_case_bits(T)   (the full vector)
+//! best_case_bits  = log₂(L + 1)                            (the empty vector)
+//! ```
+//!
+//! # Deliberate design decision: uniform, not cardinality-weighted, length
+//!
+//! A *cardinality*-weighted length prefix (interval width `W(T)^k` for length
+//! `k`, à la [`crate::WeightedModel`]) would make every value of `Vec<T>` cost
+//! exactly `log₂ W(Vec<T>)` bits — matching the minimax-optimal scheme used
+//! for enums (see the crate documentation). But it would also make the
+//! **empty** vector cost almost as much as the **longest** one, since nearly
+//! all of `W(Vec<T>)`'s cardinality lives in the `k = L` term. That defeats
+//! the purpose of a variable-length field: short values should be cheap. The
+//! uniform length prefix trades a worst-case redundancy of
+//! `log₂(L + 1) − log₂(A / (A − 1))` bits (where `A = W(T)`) for exactly that
+//! property — a short vector costs `log₂(L + 1) + k · log₂ A`, not
+//! `log₂ W(Vec<T>)` regardless of `k`. A cardinality-weighted opt-in can be
+//! added later; it is not implemented here.
+//!
+//! Because the length prefix is uniform, `Vec<T>`'s `best_case_bits` and
+//! `worst_case_bits` genuinely differ (unlike every uniformly-weighted
+//! fixed-size type), so the pre-decode length window (see
+//! [`crate::DecodeError::Length`]) is wide rather than pinned to an exact
+//! value — it still never rejects a genuinely valid encoding.
+
+use std::{convert::Infallible, ops::Range};
+
+use arithmetic_coding::one_shot;
+use bitstream_io::{BitRead, BitWrite};
+
+use crate::{
+    DecodeError, DecodeVisitor, EncodeError, EncodeVisitor, EncodeableCustom, SizeReport, Weight,
+};
+
+/// A uniform one-shot model over `0..=max_len` — the length prefix shared by
+/// [`SeqModel`]/[`crate::StringModel`].
+///
+/// This is a runtime-sized sibling of [`crate::OneShot`] (which needs its
+/// symbol count as a `const` generic); `max_len` is only known at runtime
+/// here, since it comes from a field's config rather than the type itself.
+#[derive(Debug, Clone, Copy)]
+struct LengthModel {
+    max_len: u32,
+}
+
+impl one_shot::Model for LengthModel {
+    type B = u128;
+    type Symbol = u32;
+    type ValueError = Infallible;
+
+    fn probability(&self, symbol: &Self::Symbol) -> Result<Range<Self::B>, Self::ValueError> {
+        let value = u128::from(*symbol);
+        #[allow(clippy::range_plus_one)]
+        Ok(value..value + 1)
+    }
+
+    fn max_denominator(&self) -> Self::B {
+        u128::from(self.max_len) + 1
+    }
+
+    fn symbol(&self, value: Self::B) -> Self::Symbol {
+        // `value < max_denominator() = max_len + 1 <= u32::MAX + 1`, but the
+        // arithmetic decoder only ever produces `value` within that bound, so
+        // this always fits `u32`.
+        u32::try_from(value).unwrap_or(u32::MAX)
+    }
+}
+
+/// The configuration for a bounded sequence: a maximum length and the
+/// per-element configuration.
+///
+/// See the module documentation for the wire format and the weight/bit-cost
+/// formulas.
+#[derive(Debug, Clone, Copy)]
+pub struct SeqModel<C> {
+    /// The maximum number of elements the sequence may contain.
+    pub max_len: u32,
+    /// The configuration shared by every element.
+    pub elem: C,
+}
+
+impl<T, C> EncodeableCustom for Vec<T>
+where
+    T: EncodeableCustom<Config = C>,
+    C: Clone,
+{
+    type Config = SeqModel<C>;
+
+    fn weight(config: &Self::Config) -> Weight {
+        let elem_weight = T::weight(&config.elem);
+
+        // Closed form when every element weighs exactly one (e.g. a `Vec` of
+        // a unit type): every term of the sum is `1`, so the total is simply
+        // `max_len + 1`. Without this, a huge `max_len` with `elem_weight ==
+        // 1` would never trip the saturation short-circuit below (the sum
+        // grows by exactly 1 each iteration, so it would take `u128::MAX`
+        // iterations to saturate) and the loop would never terminate in
+        // practice.
+        if elem_weight == Weight::ONE {
+            return Weight::new(u128::from(config.max_len) + 1);
+        }
+
+        // General case: Σ_{k=0}^{max_len} elem_weight^k, saturating. This
+        // loop always terminates quickly regardless of `max_len`: once
+        // `elem_weight > 1`, the running total saturates (or the running
+        // power underflows to zero, for `elem_weight == 0`) within at most a
+        // few hundred iterations.
+        let mut total = Weight::ZERO;
+        let mut power = Weight::ONE;
+        for _ in 0..=config.max_len {
+            total = total + power;
+            if total.is_saturated() || power == Weight::ZERO {
+                return total;
+            }
+            power = power * elem_weight;
+        }
+        total
+    }
+
+    fn worst_case_bits(config: &Self::Config) -> f64 {
+        let length_bits = length_bits(config.max_len);
+        f64::from(config.max_len).mul_add(T::worst_case_bits(&config.elem), length_bits)
+    }
+
+    fn best_case_bits(config: &Self::Config) -> f64 {
+        // The cheapest value is the empty vector: just the length prefix.
+        length_bits(config.max_len)
+    }
+
+    fn report(config: &Self::Config) -> SizeReport {
+        // A compact tree — a `length` leaf plus one element *template* —
+        // rather than one node per slot: `max_len` may be in the billions,
+        // and this report is built on every `decode_bytes` call. The node's
+        // bit total is computed arithmetically instead of summed from
+        // children, so it stays exact.
+        let length_leaf = SizeReport::leaf(length_bits(config.max_len)).with_name("length");
+        let element =
+            T::report(&config.elem).with_name(format!("element (worst case × {})", config.max_len));
+        SizeReport {
+            name: None,
+            bits: Self::worst_case_bits(config),
+            children: vec![length_leaf, element],
+        }
+    }
+
+    fn encode_with_config<W>(
+        &self,
+        visitor: &mut EncodeVisitor<W>,
+        config: Self::Config,
+    ) -> Result<(), EncodeError>
+    where
+        W: BitWrite,
+    {
+        let len = self.len();
+        if len > config.max_len as usize {
+            // No clamping mode for sequences: truncation would silently
+            // drop elements, which is not a nearest-value projection.
+            return Err(EncodeError::TooLong {
+                len,
+                max_len: config.max_len,
+            });
+        }
+        // `len <= config.max_len`, a `u32`, so this cast cannot truncate.
+        #[allow(clippy::cast_possible_truncation)]
+        let len_symbol = len as u32;
+
+        visitor.encode_one(
+            LengthModel {
+                max_len: config.max_len,
+            },
+            &len_symbol,
+        )?;
+        for item in self {
+            item.encode_with_config(visitor, config.elem.clone())?;
+        }
+        Ok(())
+    }
+
+    fn decode_with_config<R>(
+        visitor: &mut DecodeVisitor<R>,
+        config: Self::Config,
+    ) -> Result<Self, DecodeError>
+    where
+        R: BitRead,
+        Self: Sized,
+    {
+        let len = visitor.decode_one(LengthModel {
+            max_len: config.max_len,
+        })?;
+        // Defensive: the length model's own denominator (`max_len + 1`) means
+        // the arithmetic decoder can never actually produce a value outside
+        // `0..=max_len`, but a corrupt stream must never be trusted to
+        // preserve that invariant, and `Vec::with_capacity` below must never
+        // be handed an unvalidated, attacker-controlled length.
+        if len > config.max_len {
+            return Err(DecodeError::InvalidSymbol {
+                symbol: u128::from(len),
+            });
+        }
+
+        let mut result = Vec::with_capacity(len as usize);
+        for _ in 0..len {
+            result.push(T::decode_with_config(visitor, config.elem.clone())?);
+        }
+        Ok(result)
+    }
+}
+
+/// `log₂(max_len + 1)`, computed without risking `u32` overflow (`max_len`
+/// may be `u32::MAX`).
+fn length_bits(max_len: u32) -> f64 {
+    (f64::from(max_len) + 1.0).log2()
+}
+
+#[cfg(test)]
+mod tests {
+    use arithmetic_coding::one_shot::Model;
+
+    use super::{LengthModel, SeqModel};
+    use crate::{EncodeableCustom, Weight};
+
+    #[test]
+    fn length_model_covers_full_range() {
+        let model = LengthModel { max_len: 5 };
+        assert_eq!(model.max_denominator(), 6);
+        for symbol in 0..=5_u32 {
+            let range = model.probability(&symbol).unwrap();
+            assert_eq!(model.symbol(range.start), symbol);
+        }
+    }
+
+    #[test]
+    fn weight_matches_geometric_sum() {
+        // elem weight 2 (bool), max_len 3: 1 + 2 + 4 + 8 = 15.
+        let config = SeqModel {
+            max_len: 3,
+            elem: (),
+        };
+        assert_eq!(
+            <Vec<bool> as EncodeableCustom>::weight(&config),
+            Weight::new(15)
+        );
+    }
+
+    #[test]
+    fn weight_with_unit_element_is_length_plus_one() {
+        // elem weight 1 (unit type): every length costs the same, so the sum
+        // is exactly max_len + 1. Also exercises that a huge max_len doesn't
+        // hang: this would need u32::MAX iterations without the closed form.
+        let config = SeqModel {
+            max_len: u32::MAX,
+            elem: (),
+        };
+        assert_eq!(
+            <Vec<()> as EncodeableCustom>::weight(&config),
+            Weight::new(u128::from(u32::MAX) + 1)
+        );
+    }
+
+    #[test]
+    fn best_case_matches_empty_vec() {
+        let config = SeqModel {
+            max_len: 10,
+            elem: (),
+        };
+        let empty: Vec<bool> = Vec::new();
+        let bytes = empty.encode_bytes_with_config(config).unwrap();
+
+        // The empty vector is the cheapest value: just the length prefix,
+        // `log2(11)` bits.
+        let best_bits = <Vec<bool> as EncodeableCustom>::best_case_bits(&config);
+        assert!((best_bits - 11_f64.log2()).abs() < 1e-9);
+        assert!(bytes.len() <= <Vec<bool> as EncodeableCustom>::report(&config).total_bytes());
+    }
+
+    #[test]
+    fn round_trips() {
+        let config = SeqModel {
+            max_len: 5,
+            elem: (),
+        };
+        for len in 0..=5 {
+            let value: Vec<bool> = vec![true; len];
+            let bytes = value.encode_bytes_with_config(config).unwrap();
+            let decoded = <Vec<bool>>::decode_bytes_with_config(&bytes, config).unwrap();
+            assert_eq!(decoded, value);
+        }
+    }
+
+    #[test]
+    fn encoding_over_max_len_is_rejected() {
+        let config = SeqModel {
+            max_len: 2,
+            elem: (),
+        };
+        let value: Vec<bool> = vec![true; 3];
+        let mut writer = bitstream_io::BitWriter::endian(Vec::new(), bitstream_io::BigEndian);
+        let mut encoder = crate::EncodeVisitor::new(crate::PRECISION, &mut writer);
+        let err = value.encode_with_config(&mut encoder, config).unwrap_err();
+        assert!(matches!(err, crate::EncodeError::TooLong { .. }));
+    }
+
+    /// The report (and the decode length check that used to build it) must
+    /// stay `O(1)` in `max_len`: a huge but valid bound must not materialise
+    /// one node per element slot.
+    #[test]
+    fn report_is_compact_for_huge_bounds() {
+        let config = SeqModel {
+            max_len: u32::MAX,
+            elem: (),
+        };
+        let report = <Vec<bool>>::report(&config);
+        // One `length` leaf plus one element template, regardless of the bound.
+        assert_eq!(report.children.len(), 2);
+
+        // The pre-decode length check runs without touching the report tree;
+        // empty input is simply outside the schema's length window.
+        let err = <Vec<bool>>::decode_bytes_with_config(&[], config).unwrap_err();
+        assert!(matches!(err, crate::DecodeError::Length { .. }));
+    }
+}

--- a/src/string.rs
+++ b/src/string.rs
@@ -1,0 +1,187 @@
+//! A model for `String` (issue #3): a bounded sequence of UTF-8 bytes.
+
+use bitstream_io::{BitRead, BitWrite};
+
+use crate::{
+    DecodeError, DecodeVisitor, EncodeError, EncodeVisitor, EncodeableCustom, IntModel, ModelError,
+    SeqModel, SizeReport, Weight,
+};
+
+/// The configuration for a [`String`] field: a maximum length **in bytes**.
+///
+/// `String` is modelled as a bounded sequence of bytes (see
+/// [`crate::SeqModel`]), each byte uniform over all 256 values — i.e.
+/// `StringModel` is exactly `SeqModel<IntModel<u8>>` under the hood, with the
+/// byte model fixed to its full-range [`Default`]. Restricting the alphabet
+/// (e.g. printable ASCII, à la DCCL) would shrink the per-byte cost below 8
+/// bits, but is not implemented here — a documented follow-up.
+///
+/// Every value round-trips as bytes; not every byte sequence is valid UTF-8,
+/// so decoding a corrupt stream can fail with
+/// [`DecodeError::InvalidUtf8`](crate::DecodeError::InvalidUtf8) rather than
+/// panicking.
+#[derive(Debug, Clone, Copy)]
+pub struct StringModel {
+    bytes: SeqModel<IntModel<u8>>,
+}
+
+impl StringModel {
+    /// Create a new [`StringModel`] with the given maximum length, in bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelError::DenominatorTooLarge`] if `max_length` does not
+    /// fit in a `u32` (the length prefix's underlying representation — see
+    /// [`SeqModel::max_len`](crate::SeqModel)); a `u32`-bounded length always
+    /// stays comfortably within
+    /// [`MAX_DENOMINATOR`](crate::MAX_DENOMINATOR), so this is the only way
+    /// construction can fail.
+    pub fn new(max_length: usize) -> Result<Self, ModelError> {
+        let max_len = u32::try_from(max_length).map_err(|_| ModelError::DenominatorTooLarge {
+            denominator: u128::try_from(max_length).unwrap_or(u128::MAX),
+            max: u128::from(u32::MAX),
+            precision: crate::PRECISION,
+        })?;
+        Ok(Self {
+            bytes: SeqModel {
+                max_len,
+                elem: IntModel::<u8>::default(),
+            },
+        })
+    }
+
+    /// The maximum length, in bytes, a [`String`] configured with this model
+    /// may occupy.
+    #[must_use]
+    pub fn max_length(&self) -> usize {
+        self.bytes.max_len as usize
+    }
+}
+
+impl EncodeableCustom for String {
+    type Config = StringModel;
+
+    fn weight(config: &Self::Config) -> Weight {
+        <Vec<u8> as EncodeableCustom>::weight(&config.bytes)
+    }
+
+    fn worst_case_bits(config: &Self::Config) -> f64 {
+        <Vec<u8> as EncodeableCustom>::worst_case_bits(&config.bytes)
+    }
+
+    fn best_case_bits(config: &Self::Config) -> f64 {
+        <Vec<u8> as EncodeableCustom>::best_case_bits(&config.bytes)
+    }
+
+    fn report(config: &Self::Config) -> SizeReport {
+        <Vec<u8> as EncodeableCustom>::report(&config.bytes)
+    }
+
+    fn encode_with_config<W>(
+        &self,
+        visitor: &mut EncodeVisitor<W>,
+        config: Self::Config,
+    ) -> Result<(), EncodeError>
+    where
+        W: BitWrite,
+    {
+        let bytes = self.as_bytes().to_vec();
+        bytes.encode_with_config(visitor, config.bytes)
+    }
+
+    fn decode_with_config<R>(
+        visitor: &mut DecodeVisitor<R>,
+        config: Self::Config,
+    ) -> Result<Self, DecodeError>
+    where
+        R: BitRead,
+        Self: Sized,
+    {
+        let bytes = <Vec<u8> as EncodeableCustom>::decode_with_config(visitor, config.bytes)?;
+        String::from_utf8(bytes).map_err(DecodeError::InvalidUtf8)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::StringModel;
+    use crate::{DecodeError, EncodeableCustom};
+
+    #[test]
+    fn max_length_round_trips() {
+        let model = StringModel::new(100).unwrap();
+        assert_eq!(model.max_length(), 100);
+    }
+
+    #[test]
+    fn round_trips_ascii_and_multibyte() {
+        for s in [
+            "",
+            "hello",
+            "héllo wörld",
+            "😀 emoji",
+            "the quick brown fox",
+        ] {
+            let config = StringModel::new(64).unwrap();
+            let bytes = s.to_string().encode_bytes_with_config(config).unwrap();
+            let decoded = String::decode_bytes_with_config(&bytes, config).unwrap();
+            assert_eq!(decoded, s);
+        }
+    }
+
+    #[test]
+    fn empty_and_max_length_round_trip() {
+        let config = StringModel::new(5).unwrap();
+
+        let empty = String::new();
+        let bytes = empty.encode_bytes_with_config(config).unwrap();
+        assert_eq!(
+            String::decode_bytes_with_config(&bytes, config).unwrap(),
+            empty
+        );
+
+        let max = "abcde".to_string();
+        let bytes = max.encode_bytes_with_config(config).unwrap();
+        assert_eq!(
+            String::decode_bytes_with_config(&bytes, config).unwrap(),
+            max
+        );
+    }
+
+    #[test]
+    fn encoding_over_max_length_is_rejected() {
+        let config = StringModel::new(2).unwrap();
+        let too_long = "abc".to_string();
+        let mut writer = bitstream_io::BitWriter::endian(Vec::new(), bitstream_io::BigEndian);
+        let mut encoder = crate::EncodeVisitor::new(crate::PRECISION, &mut writer);
+        let err = too_long
+            .encode_with_config(&mut encoder, config)
+            .unwrap_err();
+        assert!(matches!(err, crate::EncodeError::TooLong { .. }));
+    }
+
+    #[test]
+    fn invalid_utf8_bytes_are_rejected_not_panicked() {
+        // Encode a raw `Vec<u8>` containing an invalid UTF-8 sequence (a lone
+        // continuation byte) using the same byte model `StringModel` uses
+        // internally, then decode it as a `String` and confirm it errors
+        // cleanly.
+        let config = StringModel::new(4).unwrap();
+        let invalid_bytes: Vec<u8> = vec![0xff, 0xfe];
+        let bytes = invalid_bytes
+            .encode_bytes_with_config(crate::SeqModel {
+                max_len: u32::try_from(config.max_length()).unwrap(),
+                elem: crate::IntModel::<u8>::default(),
+            })
+            .unwrap();
+
+        let err = String::decode_bytes_with_config(&bytes, config).unwrap_err();
+        assert!(matches!(err, DecodeError::InvalidUtf8(_)));
+    }
+
+    #[test]
+    fn rejects_max_length_over_u32() {
+        let err = StringModel::new(usize::MAX).unwrap_err();
+        assert!(matches!(err, crate::ModelError::DenominatorTooLarge { .. }));
+    }
+}

--- a/tests/adversarial.rs
+++ b/tests/adversarial.rs
@@ -5,7 +5,7 @@
 //! and truncated byte strings through `decode_bytes` for a few representative
 //! types and assert only that the process does not panic.
 
-use minnow::Encodeable;
+use minnow::{Encodeable, EncodeableCustom};
 
 #[derive(Debug, Encodeable, PartialEq)]
 pub enum VehicleClass {
@@ -20,6 +20,19 @@ pub struct Report {
     pub x: f64,
     pub vehicle_class: Option<VehicleClass>,
     pub battery_ok: Option<bool>,
+}
+
+/// A fixture exercising the variable-length models: a bounded `Vec` (issue
+/// #5) and a bounded `String` (issue #3), both of which decode a length
+/// prefix from untrusted input before looping — exactly the code path that
+/// must reject a corrupt/oversized decoded length rather than trying to
+/// allocate or read past `max_len`/`max_length`.
+#[derive(Debug, Encodeable, PartialEq)]
+pub struct WithSequences {
+    #[encode(seq(max_len = 6))]
+    pub flags: Vec<bool>,
+    #[encode(string(max_length = 12))]
+    pub label: String,
 }
 
 /// A tiny deterministic PRNG (`xorshift64*`) so the test is reproducible
@@ -68,6 +81,22 @@ fn random_bytes_never_panic() {
         assert_no_panic::<Option<bool>>(&buf);
         assert_no_panic::<VehicleClass>(&buf);
         assert_no_panic::<Report>(&buf);
+        assert_no_panic::<WithSequences>(&buf);
+
+        // `Vec`/`String` have no `Default` config (there is no sensible
+        // universal `max_len`/`max_length`), so they aren't `Encodeable` and
+        // must be exercised through `decode_bytes_with_config` directly.
+        let _ = <Vec<bool> as minnow::EncodeableCustom>::decode_bytes_with_config(
+            &buf,
+            minnow::SeqModel {
+                max_len: 6,
+                elem: (),
+            },
+        );
+        let _ = <String as minnow::EncodeableCustom>::decode_bytes_with_config(
+            &buf,
+            minnow::StringModel::new(12).unwrap(),
+        );
     }
 }
 
@@ -79,7 +108,7 @@ fn truncated_valid_encodings_never_panic() {
         vehicle_class: Some(VehicleClass::Ship),
         battery_ok: Some(false),
     };
-    let encoded = report.encode_bytes();
+    let encoded = report.encode_bytes().unwrap();
 
     for len in 0..=encoded.len() {
         assert_no_panic::<Report>(&encoded[..len]);
@@ -87,17 +116,79 @@ fn truncated_valid_encodings_never_panic() {
 
     // Also exercise the simple leaf/​sum types.
     for value in [true, false] {
-        let bytes = value.encode_bytes();
+        let bytes = value.encode_bytes().unwrap();
         for len in 0..=bytes.len() {
             assert_no_panic::<bool>(&bytes[..len]);
         }
     }
 
     for value in [Some(true), Some(false), None] {
-        let bytes = value.encode_bytes();
+        let bytes = value.encode_bytes().unwrap();
         for len in 0..=bytes.len() {
             assert_no_panic::<Option<bool>>(&bytes[..len]);
         }
+    }
+
+    // And a fixture with variable-length (`Vec`/`String`) fields: truncating
+    // mid-way through the length prefix or the element/byte payload must
+    // still never panic.
+    let with_sequences = WithSequences {
+        flags: vec![true, false, true, true],
+        label: "hello".to_string(),
+    };
+    let bytes = with_sequences.encode_bytes().unwrap();
+    for len in 0..=bytes.len() {
+        assert_no_panic::<WithSequences>(&bytes[..len]);
+    }
+}
+
+#[test]
+fn corrupt_and_truncated_sequences_never_panic_or_oom() {
+    // Every byte slice — random garbage or a truncation of a real encoding —
+    // fed through a `Vec`/`String` decode must terminate in `Ok`/`Err`, never
+    // panic and never attempt to allocate/read beyond `max_len`/`max_length`.
+    let seq_config = minnow::SeqModel {
+        max_len: 6_u32,
+        elem: (),
+    };
+    let string_config = minnow::StringModel::new(12).unwrap();
+
+    let valid_vec: Vec<bool> = vec![true, false, true];
+    let valid_vec_bytes = valid_vec.encode_bytes_with_config(seq_config).unwrap();
+    let valid_string = "hello!".to_string();
+    let valid_string_bytes = valid_string
+        .encode_bytes_with_config(string_config)
+        .unwrap();
+
+    let mut rng = Rng::new(0xc0ff_ee00);
+    for _ in 0..5_000 {
+        let len = (rng.next_u64() % 16) as usize;
+        let mut buf = vec![0u8; len];
+        rng.fill(&mut buf);
+
+        if let Ok(decoded) =
+            <Vec<bool> as minnow::EncodeableCustom>::decode_bytes_with_config(&buf, seq_config)
+        {
+            assert!(decoded.len() <= seq_config.max_len as usize);
+        }
+        if let Ok(decoded) =
+            <String as minnow::EncodeableCustom>::decode_bytes_with_config(&buf, string_config)
+        {
+            assert!(decoded.len() <= string_config.max_length());
+        }
+    }
+
+    for len in 0..=valid_vec_bytes.len() {
+        let _ = <Vec<bool> as minnow::EncodeableCustom>::decode_bytes_with_config(
+            &valid_vec_bytes[..len],
+            seq_config,
+        );
+    }
+    for len in 0..=valid_string_bytes.len() {
+        let _ = <String as minnow::EncodeableCustom>::decode_bytes_with_config(
+            &valid_string_bytes[..len],
+            string_config,
+        );
     }
 }
 
@@ -111,7 +202,7 @@ fn truncations_are_rejected() {
         vehicle_class: Some(VehicleClass::Ship),
         battery_ok: Some(false),
     };
-    let encoded = report.encode_bytes();
+    let encoded = report.encode_bytes().unwrap();
 
     assert!(
         Report::decode_bytes(&encoded).is_ok(),
@@ -144,7 +235,7 @@ fn valid_round_trip_still_works() {
         vehicle_class: Some(VehicleClass::Auv),
         battery_ok: None,
     };
-    let encoded = report.encode_bytes();
+    let encoded = report.encode_bytes().unwrap();
     let decoded = Report::decode_bytes(&encoded).unwrap();
     assert_eq!(report, decoded);
 }

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -12,7 +12,7 @@ fn round_trip() {
         three_vec: [1.0, 2.0, 3.0],
     };
 
-    let compressed = input.encode_bytes();
+    let compressed = input.encode_bytes().unwrap();
 
     let output = MyStruct::decode_bytes(&compressed).unwrap();
 

--- a/tests/custom_config.rs
+++ b/tests/custom_config.rs
@@ -41,14 +41,15 @@ impl EncodeableCustom for Bounded {
         &self,
         visitor: &mut EncodeVisitor<W>,
         config: Self::Config,
-    ) -> std::io::Result<()>
+    ) -> Result<(), minnow::EncodeError>
     where
         W: bitstream_io::BitWrite,
     {
         let model = minnow::WeightedModel::new(vec![1_u128; config.denominator() as usize]);
         #[allow(clippy::cast_sign_loss)]
         let symbol = (self.0 - config.min) as u32;
-        visitor.encode_one(model, &symbol)
+        visitor.encode_one(model, &symbol)?;
+        Ok(())
     }
 
     fn decode_with_config<R>(
@@ -74,7 +75,7 @@ pub struct WithCustomModel {
 #[test]
 fn custom_model_round_trips() {
     let input = WithCustomModel { level: Bounded(-3) };
-    let bytes = input.encode_bytes();
+    let bytes = input.encode_bytes().unwrap();
     let output = WithCustomModel::decode_bytes(&bytes).unwrap();
     assert_eq!(input, output);
 }
@@ -107,13 +108,13 @@ fn config_expr_matches_float_sugar() {
     let expr = ViaConfigExpr { x: 42.5 };
 
     // Same underlying model, so the wire format is identical.
-    assert_eq!(sugar.encode_bytes(), expr.encode_bytes());
+    assert_eq!(sugar.encode_bytes().unwrap(), expr.encode_bytes().unwrap());
     assert_eq!(
         ViaSugar::size_report().total_bytes(),
         ViaConfigExpr::size_report().total_bytes()
     );
 
-    let bytes = expr.encode_bytes();
+    let bytes = expr.encode_bytes().unwrap();
     let decoded = ViaConfigExpr::decode_bytes(&bytes).unwrap();
     assert_eq!(decoded, expr);
 }

--- a/tests/custom_config.rs
+++ b/tests/custom_config.rs
@@ -1,0 +1,119 @@
+//! `#[encode(config = <expr>)]` (issue #8): an arbitrary Rust expression
+//! evaluated at runtime as a field's config. Covers both a builtin model
+//! constructed indirectly (proving the sugar and the general form produce
+//! the same wire format) and a fully custom, hand-written `EncodeableCustom`
+//! leaf whose config is not `float`/`string` sugar at all.
+
+use minnow::{DecodeError, DecodeVisitor, EncodeVisitor, Encodeable, EncodeableCustom, Weight};
+
+// --- A custom leaf type with its own bespoke config -------------------------
+
+/// A value clamped to a small inclusive integer range, encoded as a uniform
+/// discriminant. Nothing like `FloatModel`/`StringModel` — this exercises
+/// `#[encode(config = ...)]` against a genuinely custom model.
+#[derive(Debug, Clone, Copy)]
+pub struct Range {
+    min: i32,
+    max: i32,
+}
+
+impl Range {
+    pub const fn new(min: i32, max: i32) -> Self {
+        Self { min, max }
+    }
+
+    fn denominator(self) -> u128 {
+        u128::from((self.max - self.min).unsigned_abs()) + 1
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Bounded(pub i32);
+
+impl EncodeableCustom for Bounded {
+    type Config = Range;
+
+    fn weight(config: &Self::Config) -> Weight {
+        Weight::new(config.denominator())
+    }
+
+    fn encode_with_config<W>(
+        &self,
+        visitor: &mut EncodeVisitor<W>,
+        config: Self::Config,
+    ) -> std::io::Result<()>
+    where
+        W: bitstream_io::BitWrite,
+    {
+        let model = minnow::WeightedModel::new(vec![1_u128; config.denominator() as usize]);
+        #[allow(clippy::cast_sign_loss)]
+        let symbol = (self.0 - config.min) as u32;
+        visitor.encode_one(model, &symbol)
+    }
+
+    fn decode_with_config<R>(
+        visitor: &mut DecodeVisitor<R>,
+        config: Self::Config,
+    ) -> Result<Self, DecodeError>
+    where
+        R: bitstream_io::BitRead,
+        Self: Sized,
+    {
+        let model = minnow::WeightedModel::new(vec![1_u128; config.denominator() as usize]);
+        let symbol = visitor.decode_one(model)?;
+        Ok(Self(config.min + symbol as i32))
+    }
+}
+
+#[derive(Debug, Encodeable, PartialEq)]
+pub struct WithCustomModel {
+    #[encode(config = Range::new(-10, 10))]
+    pub level: Bounded,
+}
+
+#[test]
+fn custom_model_round_trips() {
+    let input = WithCustomModel { level: Bounded(-3) };
+    let bytes = input.encode_bytes();
+    let output = WithCustomModel::decode_bytes(&bytes).unwrap();
+    assert_eq!(input, output);
+}
+
+#[test]
+fn custom_model_weight_matches_range() {
+    assert_eq!(
+        <Bounded as EncodeableCustom>::weight(&Range::new(-10, 10)).get(),
+        21
+    );
+}
+
+// --- `config = <expr>` as a general form of the float sugar -----------------
+
+#[derive(Debug, Encodeable, PartialEq, Clone, Copy)]
+pub struct ViaSugar {
+    #[encode(float(min = -100.0, max = 100.0, precision = 1))]
+    pub x: f64,
+}
+
+#[derive(Debug, Encodeable, PartialEq, Clone, Copy)]
+pub struct ViaConfigExpr {
+    #[encode(config = minnow::FloatModel::new(-100.0..=100.0, 1).unwrap())]
+    pub x: f64,
+}
+
+#[test]
+fn config_expr_matches_float_sugar() {
+    let sugar = ViaSugar { x: 42.5 };
+    let expr = ViaConfigExpr { x: 42.5 };
+
+    // Same underlying model, so the wire format is identical.
+    assert_eq!(sugar.encode_bytes(), expr.encode_bytes());
+    assert_eq!(
+        ViaSugar::size_report().total_bytes(),
+        ViaConfigExpr::size_report().total_bytes()
+    );
+
+    let bytes = expr.encode_bytes();
+    let decoded = ViaConfigExpr::decode_bytes(&bytes).unwrap();
+    assert_eq!(decoded, expr);
+}

--- a/tests/dccl_comparison.rs
+++ b/tests/dccl_comparison.rs
@@ -1,0 +1,100 @@
+//! Pins down `examples/dccl_comparison.rs`'s headline numbers as a regression
+//! test: Minnow's actual encoded bytes for a bounded `Vec<NavigationReport>`
+//! must never exceed DCCL3's documented worst-case formula for the same
+//! schema, at every table row the example prints.
+//!
+//! See `examples/dccl_comparison.rs` for the derivation of the DCCL formula
+//! (per-field `ceil(log2(N))` whole-bit packing, `18+18+13+2+2 = 53`
+//! bits/report, a `ceil(log2(max_repeat+1))`-bit count prefix, a 1-byte
+//! message ID, byte-padded once) and the caveat that the DCCL side is
+//! formula-based, not measured against a real `libdccl` build.
+
+use minnow::Encodeable;
+
+#[derive(Debug, Encodeable, PartialEq, Clone, Copy)]
+pub enum VehicleClass {
+    Auv,
+    Usv,
+    Ship,
+}
+
+#[derive(Debug, Encodeable, PartialEq, Clone, Copy)]
+pub struct NavigationReport {
+    #[encode(float(min = -10_000.0, max = 10_000.0, precision = 1))]
+    pub x: f64,
+    #[encode(float(min = -10_000.0, max = 10_000.0, precision = 1))]
+    pub y: f64,
+    #[encode(float(min = -5_000.0, max = 0.0, precision = 0))]
+    pub z: f64,
+    pub vehicle_class: Option<VehicleClass>,
+    pub battery_ok: Option<bool>,
+}
+
+#[derive(Debug, Encodeable, PartialEq, Clone)]
+pub struct Fleet {
+    #[encode(seq(max_len = 16))]
+    pub reports: Vec<NavigationReport>,
+}
+
+const MAX_REPEAT: u32 = 16;
+const DCCL_BITS_PER_REPORT: u32 = 18 + 18 + 13 + 2 + 2;
+
+fn dccl_bytes(n: u32) -> u32 {
+    let message_id_bits = 8;
+    let count_bits = (MAX_REPEAT + 1).ilog2() + 1;
+    let total_bits = message_id_bits + count_bits + n * DCCL_BITS_PER_REPORT;
+    total_bits.div_ceil(8)
+}
+
+fn sample_report(seed: u32) -> NavigationReport {
+    #[allow(clippy::cast_precision_loss)]
+    let seed_f = f64::from(seed);
+    NavigationReport {
+        x: (seed_f * 137.0) % 10_000.0 - 5_000.0,
+        y: (seed_f * 91.0) % 10_000.0 - 5_000.0,
+        z: -((seed_f * 53.0) % 5_000.0),
+        vehicle_class: match seed % 4 {
+            0 => None,
+            1 => Some(VehicleClass::Auv),
+            2 => Some(VehicleClass::Usv),
+            _ => Some(VehicleClass::Ship),
+        },
+        battery_ok: Some(seed.is_multiple_of(2)),
+    }
+}
+
+#[test]
+fn minnow_beats_dccl_worst_case_at_every_table_row() {
+    // Matches the table `examples/dccl_comparison.rs` prints.
+    let expected_dccl = [(1, 9), (5, 35), (10, 68), (16, 108)];
+
+    for (n, expected_dccl_bytes) in expected_dccl {
+        let dccl = dccl_bytes(n);
+        assert_eq!(dccl, expected_dccl_bytes, "DCCL formula drifted for n={n}");
+
+        let fleet = Fleet {
+            reports: (0..n).map(sample_report).collect(),
+        };
+        let minnow_bytes = fleet.encode_bytes().unwrap().len();
+
+        assert!(
+            (minnow_bytes as u32) <= dccl,
+            "minnow ({minnow_bytes} bytes) should never exceed DCCL's worst case ({dccl} bytes) \
+             at n={n}"
+        );
+
+        let decoded = Fleet::decode_bytes(&fleet.encode_bytes().unwrap()).unwrap();
+        assert_eq!(decoded, fleet);
+    }
+}
+
+#[test]
+fn ten_reports_matches_plan_headline_figures() {
+    // The specific numbers called out in the design docs: DCCL 68 bytes vs
+    // minnow 65 for a 10-report fleet.
+    let fleet = Fleet {
+        reports: (0..10).map(sample_report).collect(),
+    };
+    assert_eq!(fleet.encode_bytes().unwrap().len(), 65);
+    assert_eq!(dccl_bytes(10), 68);
+}

--- a/tests/generic_struct.rs
+++ b/tests/generic_struct.rs
@@ -1,0 +1,56 @@
+//! Generic structs (and enums): `generics.split_for_impl()` plus derive-added
+//! `EncodeableCustom` bounds, exercised end-to-end.
+
+use minnow::Encodeable;
+
+#[derive(Debug, Encodeable, PartialEq, Clone, Copy)]
+pub struct Wrapper<T> {
+    pub inner: T,
+}
+
+#[derive(Debug, Encodeable, PartialEq, Clone, Copy)]
+pub struct Pair<A, B> {
+    pub first: A,
+    pub second: B,
+}
+
+#[derive(Debug, Encodeable, PartialEq, Clone, Copy)]
+pub enum Either<A, B> {
+    Left(A),
+    Right(B),
+}
+
+#[test]
+fn single_type_param_round_trips() {
+    for value in [Wrapper { inner: true }, Wrapper { inner: false }] {
+        let bytes = value.encode_bytes();
+        let decoded = Wrapper::<bool>::decode_bytes(&bytes).unwrap();
+        assert_eq!(decoded, value);
+    }
+}
+
+#[test]
+fn two_type_params_round_trip() {
+    let value = Pair {
+        first: true,
+        second: false,
+    };
+    let bytes = value.encode_bytes();
+    let decoded = Pair::<bool, bool>::decode_bytes(&bytes).unwrap();
+    assert_eq!(decoded, value);
+}
+
+#[test]
+fn generic_enum_round_trips() {
+    for value in [Either::<bool, bool>::Left(true), Either::Right(false)] {
+        let bytes = value.encode_bytes();
+        let decoded = Either::<bool, bool>::decode_bytes(&bytes).unwrap();
+        assert_eq!(decoded, value);
+    }
+}
+
+#[test]
+fn generic_struct_weight_matches_field_weight() {
+    // `Wrapper<bool>` has exactly as many values as `bool` itself.
+    assert_eq!(Wrapper::<bool>::worst_case_bits(), bool::worst_case_bits());
+}

--- a/tests/generic_struct.rs
+++ b/tests/generic_struct.rs
@@ -23,7 +23,7 @@ pub enum Either<A, B> {
 #[test]
 fn single_type_param_round_trips() {
     for value in [Wrapper { inner: true }, Wrapper { inner: false }] {
-        let bytes = value.encode_bytes();
+        let bytes = value.encode_bytes().unwrap();
         let decoded = Wrapper::<bool>::decode_bytes(&bytes).unwrap();
         assert_eq!(decoded, value);
     }
@@ -35,7 +35,7 @@ fn two_type_params_round_trip() {
         first: true,
         second: false,
     };
-    let bytes = value.encode_bytes();
+    let bytes = value.encode_bytes().unwrap();
     let decoded = Pair::<bool, bool>::decode_bytes(&bytes).unwrap();
     assert_eq!(decoded, value);
 }
@@ -43,7 +43,7 @@ fn two_type_params_round_trip() {
 #[test]
 fn generic_enum_round_trips() {
     for value in [Either::<bool, bool>::Left(true), Either::Right(false)] {
-        let bytes = value.encode_bytes();
+        let bytes = value.encode_bytes().unwrap();
         let decoded = Either::<bool, bool>::decode_bytes(&bytes).unwrap();
         assert_eq!(decoded, value);
     }

--- a/tests/int_model.rs
+++ b/tests/int_model.rs
@@ -1,0 +1,150 @@
+//! Round-trip and size-law tests for bounded integers (`IntModel`, issue #3's
+//! numeric sibling), both hand-configured and via the `#[encode(int(...))]`
+//! derive sugar.
+
+use minnow::{Encodeable, EncodeableCustom, IntModel};
+
+#[derive(Debug, Encodeable, PartialEq, Clone, Copy)]
+pub struct Reading {
+    // A small signed range, well within a single byte.
+    #[encode(int(min = -10, max = 10))]
+    pub delta: i32,
+    // `u8`'s `Default` config spans its full native range.
+    pub raw: u8,
+    // `u64` has no `Default`, so it always needs an explicit range.
+    #[encode(int(min = 0, max = 1_000_000))]
+    pub counter: u64,
+}
+
+// --- Round-trips at the extremes --------------------------------------------
+
+#[test]
+fn round_trips_at_extremes() {
+    for delta in [-10, -1, 0, 1, 10] {
+        for raw in [u8::MIN, 128, u8::MAX] {
+            for counter in [0, 500_000, 1_000_000] {
+                let value = Reading {
+                    delta,
+                    raw,
+                    counter,
+                };
+                let bytes = value.encode_bytes().unwrap();
+                let decoded = Reading::decode_bytes(&bytes).unwrap();
+                assert_eq!(decoded, value);
+            }
+        }
+    }
+}
+
+#[test]
+fn negative_only_range_round_trips() {
+    let config = IntModel::new(-1000_i32..=-1).unwrap();
+    for value in [-1000, -500, -1] {
+        let bytes = value.encode_bytes_with_config(config).unwrap();
+        let decoded = i32::decode_bytes_with_config(&bytes, config).unwrap();
+        assert_eq!(decoded, value);
+    }
+}
+
+#[test]
+fn single_value_range_costs_zero_bits() {
+    // A range with min == max has exactly one encodable value: weight 1,
+    // zero payload bits (matching a unit struct).
+    let config = IntModel::new(42_i32..=42).unwrap();
+    assert_eq!(<i32 as EncodeableCustom>::weight(&config).get(), 1);
+    assert_eq!(<i32 as EncodeableCustom>::worst_case_bits(&config), 0.0);
+    let bytes = 42_i32.encode_bytes_with_config(config).unwrap();
+    assert_eq!(i32::decode_bytes_with_config(&bytes, config).unwrap(), 42);
+}
+
+#[test]
+fn i64_and_u64_extremes_round_trip() {
+    let signed = IntModel::new(i64::MIN..=i64::MIN + 1_000_000).unwrap();
+    for value in [i64::MIN, i64::MIN + 500_000, i64::MIN + 1_000_000] {
+        let bytes = value.encode_bytes_with_config(signed).unwrap();
+        assert_eq!(
+            i64::decode_bytes_with_config(&bytes, signed).unwrap(),
+            value
+        );
+    }
+
+    let unsigned = IntModel::new(u64::MAX - 1_000_000..=u64::MAX).unwrap();
+    for value in [u64::MAX - 1_000_000, u64::MAX - 500_000, u64::MAX] {
+        let bytes = value.encode_bytes_with_config(unsigned).unwrap();
+        assert_eq!(
+            u64::decode_bytes_with_config(&bytes, unsigned).unwrap(),
+            value
+        );
+    }
+}
+
+// --- Size law ----------------------------------------------------------------
+
+#[test]
+fn size_law_holds() {
+    let upper = Reading::size_report().total_bytes();
+    let mut lengths = Vec::new();
+    for delta in [-10, 0, 10] {
+        for raw in [0, 255] {
+            for counter in [0, 1_000_000] {
+                let value = Reading {
+                    delta,
+                    raw,
+                    counter,
+                };
+                let bytes = value.encode_bytes().unwrap();
+                assert!(bytes.len() <= upper);
+                lengths.push(bytes.len());
+            }
+        }
+    }
+    // Uniform weighting: every value should encode to (near enough) the same
+    // length.
+    let min = *lengths.iter().min().unwrap();
+    let max = *lengths.iter().max().unwrap();
+    assert!(max - min <= 1, "min={min} max={max}");
+}
+
+#[test]
+fn worst_case_bits_matches_formula() {
+    // delta: 21 values -> log2(21); raw: 256 values -> log2(256) = 8;
+    // counter: 1_000_001 values -> log2(1_000_001).
+    let expected = 21_f64.log2() + 256_f64.log2() + 1_000_001_f64.log2();
+    let bits = <Reading as Encodeable>::worst_case_bits();
+    assert!(
+        (bits - expected).abs() < 1e-9,
+        "expected {expected}, got {bits}"
+    );
+}
+
+/// Encode-domain semantics through the derive: out-of-range values error by
+/// default and clamp only under the explicit `clamping` flag.
+#[test]
+fn out_of_range_errors_by_default_and_clamps_on_opt_in() {
+    #[derive(Debug, Encodeable, PartialEq, Eq)]
+    struct Strict {
+        #[encode(int(min = 0, max = 10))]
+        value: u8,
+    }
+
+    #[derive(Debug, Encodeable, PartialEq, Eq)]
+    struct Clamped {
+        #[encode(int(min = 0, max = 10, clamping))]
+        value: u8,
+    }
+
+    assert!(matches!(
+        Strict { value: 200 }.encode_bytes(),
+        Err(minnow::EncodeError::OutOfRange { .. })
+    ));
+
+    let encoded = Clamped { value: 200 }.encode_bytes().unwrap();
+    assert_eq!(
+        Clamped::decode_bytes(&encoded).unwrap(),
+        Clamped { value: 10 }
+    );
+
+    // In-range values are untouched in either mode.
+    let encoded = Strict { value: 7 }.encode_bytes().unwrap();
+    assert_eq!(Strict::decode_bytes(&encoded).unwrap(), Strict { value: 7 });
+}

--- a/tests/manual_weight.rs
+++ b/tests/manual_weight.rs
@@ -33,8 +33,8 @@ fn repeated_heavy_variant_encodes_smaller() {
     let commons = [Biased::Common; 64];
     let rares = [Biased::Rare; 64];
 
-    let common_len = commons.encode_bytes().len();
-    let rare_len = rares.encode_bytes().len();
+    let common_len = commons.encode_bytes().unwrap().len();
+    let rare_len = rares.encode_bytes().unwrap().len();
 
     assert!(
         common_len < rare_len,
@@ -43,8 +43,8 @@ fn repeated_heavy_variant_encodes_smaller() {
 
     // Both still round-trip, even though their lengths differ wildly: the decode
     // length check must not reject the (very short) all-Common encoding.
-    let commons_bytes = commons.encode_bytes();
-    let rares_bytes = rares.encode_bytes();
+    let commons_bytes = commons.encode_bytes().unwrap();
+    let rares_bytes = rares.encode_bytes().unwrap();
     assert_eq!(
         <[Biased; 64]>::decode_bytes(&commons_bytes).unwrap(),
         commons

--- a/tests/nested_vec.rs
+++ b/tests/nested_vec.rs
@@ -1,0 +1,103 @@
+//! `Vec<NavigationReport>`-style nesting: a derived struct (whose own
+//! `Config` is always `()`, so it needs no `elem` expression in the `seq(...)`
+//! sugar) collected into a bounded `Vec`. This is the shape Phase 5's DCCL
+//! comparison example builds on (a fleet of reports in one message).
+
+use minnow::Encodeable;
+
+#[derive(Debug, Encodeable, PartialEq, Clone, Copy)]
+pub enum VehicleClass {
+    Auv,
+    Usv,
+    Ship,
+}
+
+#[derive(Debug, Encodeable, PartialEq, Clone, Copy)]
+pub struct NavigationReport {
+    #[encode(float(min = -10_000.0, max = 10_000.0, precision = 1))]
+    pub x: f64,
+    #[encode(float(min = -10_000.0, max = 10_000.0, precision = 1))]
+    pub y: f64,
+    #[encode(float(min = -5_000.0, max = 0.0, precision = 0))]
+    pub z: f64,
+    pub vehicle_class: Option<VehicleClass>,
+    pub battery_ok: Option<bool>,
+}
+
+/// A bounded fleet of navigation reports: `NavigationReport::Config == ()`,
+/// which implements `Default`, so `elem` is omitted entirely — the same
+/// sugar as an unannotated leaf field.
+#[derive(Debug, Encodeable, PartialEq, Clone)]
+pub struct Fleet {
+    #[encode(seq(max_len = 10))]
+    pub reports: Vec<NavigationReport>,
+}
+
+fn sample_report(seed: u32) -> NavigationReport {
+    #[allow(clippy::cast_precision_loss)]
+    let seed = f64::from(seed);
+    NavigationReport {
+        x: (seed * 137.0) % 10_000.0 - 5_000.0,
+        y: (seed * 91.0) % 10_000.0 - 5_000.0,
+        z: -((seed * 53.0) % 5_000.0),
+        vehicle_class: match seed as u32 % 4 {
+            0 => None,
+            1 => Some(VehicleClass::Auv),
+            2 => Some(VehicleClass::Usv),
+            _ => Some(VehicleClass::Ship),
+        },
+        battery_ok: Some((seed as u32).is_multiple_of(2)),
+    }
+}
+
+#[test]
+fn round_trips_at_length_extremes() {
+    for len in [0, 1, 10] {
+        let fleet = Fleet {
+            reports: (0..len).map(sample_report).collect(),
+        };
+        let bytes = fleet.encode_bytes().unwrap();
+        let decoded = Fleet::decode_bytes(&bytes).unwrap();
+        assert_eq!(decoded, fleet);
+    }
+}
+
+#[test]
+fn size_matches_length_prefix_plus_reports() {
+    // Each report's worst-case size: `NavigationReport`'s own report total
+    // (17.6096*2 + 12.2882 + 2.0 + 1.585, see tests/size_law.rs), plus the
+    // uniform length prefix over 0..=10 (log2(11) bits), plus coder
+    // termination — matching `SeqModel`'s documented
+    // `worst_case_bits = log2(L+1) + L * worst_case_bits(elem)` formula.
+    let report_bits = <NavigationReport as Encodeable>::worst_case_bits();
+    let length_bits = 11_f64.log2();
+    let expected_worst = length_bits + 10.0 * report_bits;
+
+    let worst = <Fleet as Encodeable>::worst_case_bits();
+    assert!(
+        (worst - expected_worst).abs() < 1e-6,
+        "expected {expected_worst}, got {worst}"
+    );
+
+    let upper = Fleet::size_report().total_bytes();
+    let full_fleet = Fleet {
+        reports: (0..10).map(sample_report).collect(),
+    };
+    let bytes = full_fleet.encode_bytes().unwrap();
+    assert!(bytes.len() <= upper);
+}
+
+#[test]
+fn beats_dccl_per_report_bit_budget() {
+    // DCCL3's default codec costs 18+18+13+2+2 = 53 bits per report
+    // (see the crate-level docs / Phase 5's DCCL comparison). Minnow's
+    // per-field float quantisation plus weighted `Option` discriminants
+    // already beats that per-report; this is the nested-`Vec` analogue of
+    // that comparison, checked directly against `NavigationReport`'s own
+    // measured worst-case bits.
+    let report_bits = <NavigationReport as Encodeable>::worst_case_bits();
+    assert!(
+        report_bits < 53.0,
+        "expected < 53 bits/report, got {report_bits}"
+    );
+}

--- a/tests/seq.rs
+++ b/tests/seq.rs
@@ -1,0 +1,144 @@
+//! Round-trip and size-law tests for `Vec<T>` (issue #5), both hand-configured
+//! (`SeqModel`) and via the `#[encode(seq(...))]` derive sugar.
+
+use minnow::{Encodeable, EncodeableCustom, FloatModel, SeqModel};
+
+#[derive(Debug, Encodeable, PartialEq, Clone, Copy)]
+pub enum Flag {
+    Red,
+    Green,
+    Blue,
+}
+
+#[derive(Debug, Encodeable, PartialEq, Clone)]
+pub struct Samples {
+    #[encode(seq(max_len = 5, elem = minnow::FloatModel::new(0.0..=10.0, 1).unwrap()))]
+    pub readings: Vec<f64>,
+    #[encode(seq(max_len = 5))]
+    pub flags: Vec<Flag>,
+}
+
+fn as_f64(i: usize) -> f64 {
+    f64::from(u32::try_from(i).unwrap())
+}
+
+// --- Round-trips at lengths {0, 1, max} -------------------------------------
+
+#[test]
+fn vec_f64_round_trips_at_length_extremes() {
+    let elem = FloatModel::new(0.0..=10.0, 1).unwrap();
+    for len in [0, 1, 5] {
+        let config = SeqModel {
+            max_len: 5,
+            elem: elem.clone(),
+        };
+        let value: Vec<f64> = (0..len).map(as_f64).collect();
+        let bytes = value.encode_bytes_with_config(config.clone()).unwrap();
+        let decoded = <Vec<f64>>::decode_bytes_with_config(&bytes, config).unwrap();
+        assert_eq!(decoded, value);
+    }
+}
+
+#[test]
+fn vec_enum_round_trips_at_length_extremes() {
+    let config = SeqModel {
+        max_len: 4,
+        elem: (),
+    };
+    let all = [Flag::Red, Flag::Green, Flag::Blue, Flag::Red];
+    for len in [0, 1, 4] {
+        let value: Vec<Flag> = all[..len].to_vec();
+        let bytes = value.encode_bytes_with_config(config).unwrap();
+        let decoded = <Vec<Flag>>::decode_bytes_with_config(&bytes, config).unwrap();
+        assert_eq!(decoded, value);
+    }
+}
+
+#[test]
+fn derive_seq_sugar_round_trips() {
+    for len in [0, 1, 5] {
+        let value = Samples {
+            readings: (0..len).map(as_f64).collect(),
+            flags: vec![Flag::Blue; len],
+        };
+        let bytes = value.encode_bytes().unwrap();
+        let decoded = Samples::decode_bytes(&bytes).unwrap();
+        assert_eq!(decoded, value);
+    }
+}
+
+// --- Size law: the tight per-length formula ---------------------------------
+//
+// For a variable-length sequence the size law is per-*value*, not a single
+// figure: a sequence of length `l` costs `log2(max_len + 1) + l * elem_bits`
+// payload bits, plus `TERMINATION_BITS` (2.0) of coder overhead, rounded up
+// to whole bytes.
+
+#[test]
+fn per_length_size_law_matches_formula() {
+    // For a *uniform* leaf, every value costs the same ideal (`f64`) number
+    // of bits, but the real arithmetic coder's actual output is an integer
+    // number of bits whose relationship to that ideal figure includes
+    // renormalisation/flush rounding (`TERMINATION_BITS` is an *upper* bound
+    // on termination cost, "at most two bits" — see `crate::TERMINATION_BITS`
+    // docs, not always exactly two). So the achieved byte length is pinned to
+    // within one byte of `ceil((length_bits + l * elem_bits +
+    // TERMINATION_BITS) / 8)` — the same one-byte tolerance
+    // `tests/size_law.rs` uses for fixed-size schemas — rather than always
+    // equal to it; and it must never exceed that figure, which is a genuine
+    // upper bound (`SizeReport::total_bytes`'s contract).
+    let elem = FloatModel::new(0.0..=10.0, 1).unwrap();
+    let elem_bits = <f64 as EncodeableCustom>::worst_case_bits(&elem);
+    let max_len = 5_u32;
+
+    for len in 0..=max_len {
+        let config = SeqModel {
+            max_len,
+            elem: elem.clone(),
+        };
+        let value: Vec<f64> = (0..len).map(|i| as_f64(i as usize)).collect();
+        let bytes = value.encode_bytes_with_config(config).unwrap();
+
+        let expected_bits = (f64::from(max_len) + 1.0).log2()
+            + f64::from(len) * elem_bits
+            + minnow::TERMINATION_BITS;
+        let expected_bytes = (expected_bits / 8.0).ceil() as usize;
+
+        assert!(
+            bytes.len() <= expected_bytes && bytes.len() + 1 >= expected_bytes,
+            "length {len}: expected {expected_bytes} bytes (±1), got {}",
+            bytes.len()
+        );
+    }
+}
+
+#[test]
+fn best_and_worst_case_bits_match_formula() {
+    let elem = FloatModel::new(0.0..=10.0, 1).unwrap();
+    let elem_bits = <f64 as EncodeableCustom>::worst_case_bits(&elem);
+    let max_len = 5_u32;
+    let config = SeqModel { max_len, elem };
+
+    let length_bits = (f64::from(max_len) + 1.0).log2();
+    assert!((<Vec<f64> as EncodeableCustom>::best_case_bits(&config) - length_bits).abs() < 1e-9);
+    let expected_worst = length_bits + f64::from(max_len) * elem_bits;
+    assert!(
+        (<Vec<f64> as EncodeableCustom>::worst_case_bits(&config) - expected_worst).abs() < 1e-9
+    );
+}
+
+// --- Weight formula ----------------------------------------------------------
+
+#[test]
+fn weight_matches_geometric_sum_formula() {
+    // elem weight 3 (Flag has 3 variants), max_len 3:
+    // 1 + 3 + 9 + 27 = 40.
+    let config = SeqModel {
+        max_len: 3,
+        elem: (),
+    };
+    assert_eq!(
+        <Vec<Flag> as EncodeableCustom>::weight(&config).get(),
+        1 + 3 + 9 + 27
+    );
+}

--- a/tests/size_law.rs
+++ b/tests/size_law.rs
@@ -104,7 +104,7 @@ where
     let mut max = 0usize;
 
     for value in values {
-        let bytes = value.encode_bytes();
+        let bytes = value.encode_bytes().unwrap();
         let len = bytes.len();
         assert!(
             len <= upper,
@@ -112,7 +112,7 @@ where
         );
         let decoded = T::decode_bytes(&bytes).expect("a valid encoding must decode");
         assert_eq!(
-            decoded.encode_bytes(),
+            decoded.encode_bytes().unwrap(),
             bytes,
             "re-encoding the decoded value must be stable",
         );
@@ -211,7 +211,7 @@ fn option_vehicle_class_is_exactly_two_bits() {
     ];
     let mut lengths = Vec::new();
     for value in values {
-        let bytes = value.encode_bytes();
+        let bytes = value.encode_bytes().unwrap();
         assert!(bytes.len() <= 1, "should fit in a single byte");
         assert_eq!(Option::<VehicleClass>::decode_bytes(&bytes).unwrap(), value);
         lengths.push(bytes.len());

--- a/tests/string.rs
+++ b/tests/string.rs
@@ -1,0 +1,104 @@
+//! Round-trip tests for `String` (issue #3), both hand-configured
+//! (`StringModel`) and via the `#[encode(string(...))]` derive sugar.
+
+use minnow::{DecodeError, Encodeable, EncodeableCustom, StringModel};
+
+#[derive(Debug, Encodeable, PartialEq, Clone)]
+pub struct Message {
+    #[encode(string(max_length = 32))]
+    pub text: String,
+}
+
+#[test]
+fn round_trips_empty_and_max_and_multibyte() {
+    let config = StringModel::new(16).unwrap();
+
+    // Empty.
+    let bytes = String::new().encode_bytes_with_config(config).unwrap();
+    assert_eq!(
+        String::decode_bytes_with_config(&bytes, config).unwrap(),
+        ""
+    );
+
+    // Exactly max_length bytes (ASCII, so 16 bytes == 16 chars).
+    let max = "0123456789abcdef".to_string();
+    assert_eq!(max.len(), 16);
+    let bytes = max.clone().encode_bytes_with_config(config).unwrap();
+    assert_eq!(
+        String::decode_bytes_with_config(&bytes, config).unwrap(),
+        max
+    );
+
+    // Multibyte UTF-8 (emoji, accented characters), well under the byte
+    // budget.
+    for s in ["héllo", "日本語", "🦀🎉", "café"] {
+        let bytes = s.to_string().encode_bytes_with_config(config).unwrap();
+        assert_eq!(String::decode_bytes_with_config(&bytes, config).unwrap(), s);
+    }
+}
+
+#[test]
+fn derive_string_sugar_round_trips() {
+    for text in ["", "hello, world!", "日本語のテスト"] {
+        let value = Message {
+            text: text.to_string(),
+        };
+        let bytes = value.encode_bytes().unwrap();
+        let decoded = Message::decode_bytes(&bytes).unwrap();
+        assert_eq!(decoded, value);
+    }
+}
+
+#[test]
+fn encoding_beyond_max_length_is_rejected_not_panicked() {
+    let value = Message {
+        // Each 'x' is a 3-byte character (well beyond the 32-byte budget in
+        // total), exercising the byte-length (not char-count) bound.
+        text: "€".repeat(20),
+    };
+    // `encode_bytes` panics on I/O failure (infallible for `Vec<u8>` in
+    // general), but exceeding `max_length` is a configuration error the
+    // fallible `encode_with_config` path must surface cleanly rather than
+    // panic.
+    let mut writer = bitstream_io::BitWriter::endian(Vec::new(), bitstream_io::BigEndian);
+    let mut encoder = minnow::EncodeVisitor::new(minnow::PRECISION, &mut writer);
+    let config = minnow_derive_config();
+    let err = value
+        .text
+        .encode_with_config(&mut encoder, config)
+        .unwrap_err();
+    assert!(matches!(err, minnow::EncodeError::TooLong { .. }));
+}
+
+fn minnow_derive_config() -> StringModel {
+    StringModel::new(32).unwrap()
+}
+
+#[test]
+fn corrupt_bytes_never_panic_and_invalid_utf8_is_reported() {
+    // Feed a hand-built, well-formed-length-but-corrupt byte sequence through
+    // `String`'s decode path and confirm it either decodes or reports
+    // `InvalidUtf8`/other `DecodeError` — never panics.
+    let config = StringModel::new(8).unwrap();
+    for len in 0..8 {
+        for fill in [0x00_u8, 0xff_u8] {
+            let raw_bytes: Vec<u8> = vec![fill; len];
+            let encoded = raw_bytes
+                .encode_bytes_with_config(minnow::SeqModel {
+                    max_len: 8,
+                    elem: minnow::IntModel::<u8>::default(),
+                })
+                .unwrap();
+            let result = String::decode_bytes_with_config(&encoded, config);
+            // Either it's a valid (if degenerate) UTF-8 string, or it's
+            // reported as invalid UTF-8 -- either way, no panic, and any
+            // error is a `DecodeError`.
+            if let Err(err) = result {
+                assert!(matches!(
+                    err,
+                    DecodeError::InvalidUtf8(_) | DecodeError::Length { .. }
+                ));
+            }
+        }
+    }
+}

--- a/tests/struct_variant_enum.rs
+++ b/tests/struct_variant_enum.rs
@@ -51,7 +51,7 @@ impl Rng {
             1 => Shape::Circle(self.range(0.0, 1_000.0), self.range(-1_000.0, 1_000.0)),
             _ => Shape::Rectangle {
                 width: self.range(0.0, 1_000.0),
-                height: self.next_u64() % 2 == 0,
+                height: self.next_u64().is_multiple_of(2),
             },
         }
     }

--- a/tests/struct_variant_enum.rs
+++ b/tests/struct_variant_enum.rs
@@ -1,0 +1,104 @@
+//! Struct-style, multi-field-tuple, and mixed unit/tuple/struct enum
+//! variants (issue #4). Verifies round-tripping *and* the size law: every
+//! value of the schema encodes to a length bounded by
+//! `size_report().total_bytes()`.
+
+use minnow::Encodeable;
+
+#[derive(Debug, Encodeable, PartialEq, Clone, Copy)]
+pub enum Shape {
+    /// Unit variant.
+    Point,
+    /// Multi-field tuple variant — attributes live on the fields now.
+    Circle(
+        #[encode(float(min = 0.0, max = 1_000.0, precision = 1))] f64,
+        #[encode(float(min = -1_000.0, max = 1_000.0, precision = 0))] f64,
+    ),
+    /// Struct variant.
+    Rectangle {
+        #[encode(float(min = 0.0, max = 1_000.0, precision = 1))]
+        width: f64,
+        height: bool,
+    },
+}
+
+// --- Tiny deterministic PRNG, matching the convention in tests/size_law.rs -
+
+struct Rng(u64);
+impl Rng {
+    fn new(seed: u64) -> Self {
+        Self(seed | 1)
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x >> 12;
+        x ^= x << 25;
+        x ^= x >> 27;
+        self.0 = x;
+        x.wrapping_mul(0x2545_f491_4f6c_dd1d)
+    }
+
+    #[allow(clippy::cast_precision_loss)]
+    fn range(&mut self, lo: f64, hi: f64) -> f64 {
+        let t = (self.next_u64() >> 11) as f64 / (1u64 << 53) as f64;
+        lo + t * (hi - lo)
+    }
+
+    fn shape(&mut self) -> Shape {
+        match self.next_u64() % 3 {
+            0 => Shape::Point,
+            1 => Shape::Circle(self.range(0.0, 1_000.0), self.range(-1_000.0, 1_000.0)),
+            _ => Shape::Rectangle {
+                width: self.range(0.0, 1_000.0),
+                height: self.next_u64() % 2 == 0,
+            },
+        }
+    }
+}
+
+#[test]
+fn round_trip_every_variant_kind() {
+    let values = [
+        Shape::Point,
+        Shape::Circle(12.5, -300.0),
+        Shape::Rectangle {
+            width: 42.0,
+            height: true,
+        },
+    ];
+    for value in values {
+        let bytes = value.encode_bytes();
+        let decoded = Shape::decode_bytes(&bytes).expect("valid encoding must decode");
+        assert_eq!(decoded, value);
+    }
+}
+
+#[test]
+fn size_law_holds_across_variant_kinds() {
+    let mut rng = Rng::new(42);
+    let upper = Shape::size_report().total_bytes();
+
+    for _ in 0..5_000 {
+        let value = rng.shape();
+        let bytes = value.encode_bytes();
+        assert!(
+            bytes.len() <= upper,
+            "{value:?} encoded to {} bytes, exceeding size_report().total_bytes() = {upper}",
+            bytes.len(),
+        );
+        let decoded = Shape::decode_bytes(&bytes).expect("a valid encoding must decode");
+        assert_eq!(decoded.encode_bytes(), bytes, "re-encoding must be stable");
+    }
+}
+
+#[test]
+fn rectangle_field_breakdown_is_named() {
+    let report = Shape::size_report();
+    let rendered = report.to_string();
+    // The `Rectangle` variant's payload children must carry the real field
+    // names, not positional indices, proving struct-variant fields flow
+    // through to the report.
+    assert!(rendered.contains("width"), "{rendered}");
+    assert!(rendered.contains("height"), "{rendered}");
+}

--- a/tests/struct_variant_enum.rs
+++ b/tests/struct_variant_enum.rs
@@ -68,7 +68,7 @@ fn round_trip_every_variant_kind() {
         },
     ];
     for value in values {
-        let bytes = value.encode_bytes();
+        let bytes = value.encode_bytes().unwrap();
         let decoded = Shape::decode_bytes(&bytes).expect("valid encoding must decode");
         assert_eq!(decoded, value);
     }
@@ -81,14 +81,18 @@ fn size_law_holds_across_variant_kinds() {
 
     for _ in 0..5_000 {
         let value = rng.shape();
-        let bytes = value.encode_bytes();
+        let bytes = value.encode_bytes().unwrap();
         assert!(
             bytes.len() <= upper,
             "{value:?} encoded to {} bytes, exceeding size_report().total_bytes() = {upper}",
             bytes.len(),
         );
         let decoded = Shape::decode_bytes(&bytes).expect("a valid encoding must decode");
-        assert_eq!(decoded.encode_bytes(), bytes, "re-encoding must be stable");
+        assert_eq!(
+            decoded.encode_bytes().unwrap(),
+            bytes,
+            "re-encoding must be stable"
+        );
     }
 }
 

--- a/tests/tuple_enum.rs
+++ b/tests/tuple_enum.rs
@@ -18,7 +18,7 @@ pub enum MyNestedEnum {
 fn round_trip() {
     let input = MyNestedEnum::B(MyEnum::A(5.0));
 
-    let compressed = input.encode_bytes();
+    let compressed = input.encode_bytes().unwrap();
 
     let output = MyNestedEnum::decode_bytes(&compressed).unwrap();
 

--- a/tests/tuple_struct.rs
+++ b/tests/tuple_struct.rs
@@ -13,7 +13,7 @@ pub struct MyNestedStruct(MyStruct);
 fn round_trip() {
     let input = MyNestedStruct(MyStruct(5.0, 10.0));
 
-    let compressed = input.encode_bytes();
+    let compressed = input.encode_bytes().unwrap();
 
     let output = MyNestedStruct::decode_bytes(&compressed).unwrap();
 

--- a/tests/unit_enum.rs
+++ b/tests/unit_enum.rs
@@ -11,7 +11,7 @@ pub enum MyEnum {
 fn round_trip() {
     let input = MyEnum::B;
 
-    let compressed = input.encode_bytes();
+    let compressed = input.encode_bytes().unwrap();
 
     let output = MyEnum::decode_bytes(&compressed).unwrap();
 


### PR DESCRIPTION
The final PR of the improvement plan — consolidates the former stack (#69/#70/#71) after their bases merged, rebased onto current `main` (bitstream-io 4, darling 0.23 with its `syn` re-export, MSRV 1.88). Closes #3, #4, #5, #8.

## Derive completeness (#4, #8)
- `#[encode(config = <expr>)]`: arbitrary config/model expressions per field — the escape hatch every other attribute form is documented sugar for, lowered through the single `Model::config_tokens` path.
- Struct and multi-field tuple enum variants with per-field attributes: a variant's payload is what it mathematically is — an anonymous product type — sharing one `FieldSpec`/`Shape` codegen path with structs. Unit structs round-trip. Generics fixed via `split_for_impl` with inferred bounds.
- trybuild UI fixtures (8 fail diagnostics + 4 pass cases) plus round-trip/size-law integration tests.

## New models (#3, #5)
- `IntModel<T>` for `u8..u64`/`i8..i64` (`int(min, max)` sugar); full-range `Default`s where they fit the denominator cap.
- `SeqModel` for `Vec<T>` and `StringModel` for UTF-8 `String`: uniform length prefix + elements, with the cardinality math and the deliberate not-cardinality-weighted trade-off documented. Compact `O(1)` size reports; decoded lengths validated before allocation; invalid UTF-8 is a typed `DecodeError`, never a panic.

## Encode-domain semantics: errors, not silent coercion
Encoding is fallible end-to-end with a typed `EncodeError`:
- `OutOfRange`: out-of-range loss is unbounded (12 000 clamped to a declared max of 10 000 reads as plausible data at the receiver), unlike in-range quantisation whose loss the schema declares — so it errors unless a field opts into clamping (`FloatModel::clamping()` / `IntModel::clamping()` / the `clamping` derive flag; the right policy for naturally saturating sensor channels, wrong for everything else).
- `NonFinite`: NaN/∞ error in every mode (no nearest representable value); also removes a latent panic in the old silent-clamp path.
- `TooLong`: over-length sequences (no clamping mode — truncation is not a nearest-value projection).

## Docs
README gains "How Minnow compresses" (the weight semiring, the minimax theorem, worked examples with verified numbers: NavigationReport 51.09 bits → 7 bytes), size-report output, encode-semantics section, supported-types table, and integrity caveats. New `weighted_enum` (#9 demo) and `dccl_comparison` examples — DCCL3's documented formula vs minnow's actual bytes: 9→**7**, 35→**33**, 68→**65**, 108→**103** at n = 1/5/10/16, asserted in tests.

144 tests green; clippy/fmt/doc clean; all five examples run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BRpeiPNoowJaMhAk2WYUMp