### PR TITLE
refactor: inherit shared workspace metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,25 @@
 [package]
 name = "minnow"
-version = "0.1.0"
+version.workspace = true
 description = "A library and derive macro for extremely compact encoding of structs using arithmetic coding."
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
+
+[workspace]
+members = [".", "minnow-derive"]
+
+[workspace.package]
+version = "0.1.0"
 edition = "2021"
+rust-version = "1.88"
 license = "GPL-3.0"
 repository = "https://github.com/danieleades/minnow"
 keywords = ["compression", "encoding", "arithmetic-coding", "lossless"]
 categories = ["compression", "encoding", "parsing"]
-rust-version = "1.88"
-
-[workspace]
-members = [".", "minnow-derive"]
 
 [dependencies]
 arithmetic-coding = "0.4"

--- a/minnow-derive/Cargo.toml
+++ b/minnow-derive/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "minnow-derive"
-version = "0.1.0"
+version.workspace = true
 description = "A derive macro for the Minnow library."
-edition = "2021"
-license = "GPL-3.0"
-repository = "https://github.com/danieleades/minnow"
-keywords = ["compression", "encoding", "arithmetic-coding", "lossless"]
-categories = ["compression", "encoding", "parsing"]
-rust-version = "1.88"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+keywords.workspace = true
+categories.workspace = true
+rust-version.workspace = true
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
## Summary

- centralize shared package metadata under `[workspace.package]`
- have both `minnow` and `minnow-derive` inherit version, edition, Rust version, license, repository, keywords, and categories
- keep each crate's distinct description in its own package manifest

## Why

The Darling 0.23 upgrade raised the workspace MSRV to Rust 1.88. Keeping shared release metadata duplicated across both crates makes values easy to drift; workspace inheritance provides one source of truth.

## Impact

This is a manifest-only refactor. Resolved package metadata and runtime behavior are unchanged.

## Validation

- `cargo metadata --format-version 1 --no-deps`
- `cargo fmt --all --check`
- `cargo hack check --rust-version --no-dev-deps --workspace`
- `cargo package --workspace --allow-dirty --no-verify`
